### PR TITLE
P0: Safety Plan access + weather card empty state

### DIFF
--- a/moodbound/Views/HomeView.swift
+++ b/moodbound/Views/HomeView.swift
@@ -6,6 +6,7 @@ struct HomeView: View {
     @Query(sort: \MoodEntry.timestamp, order: .reverse) private var entries: [MoodEntry]
     @State private var showingNewEntry = false
     @State private var showingSettings = false
+    @State private var showingSafetyPlan = false
     @State private var viewModel = MoodViewModel()
     @AppStorage(AppClock.overrideTimestampKey) private var overrideTimestamp: Double = 0
 
@@ -28,6 +29,16 @@ struct HomeView: View {
             }
             .navigationTitle("Today")
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        showingSafetyPlan = true
+                    } label: {
+                        Image(systemName: "cross.case.fill")
+                            .foregroundStyle(.red.opacity(0.85))
+                    }
+                    .accessibilityLabel("Safety Plan")
+                    .accessibilityIdentifier("safety-plan-button")
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         showingSettings = true
@@ -42,6 +53,9 @@ struct HomeView: View {
             }
             .sheet(isPresented: $showingSettings) {
                 SettingsView()
+            }
+            .sheet(isPresented: $showingSafetyPlan) {
+                SafetyPlanView()
             }
         }
         .animation(.smooth(duration: 0.28), value: entries.count)

--- a/moodbound/Views/InsightsView.swift
+++ b/moodbound/Views/InsightsView.swift
@@ -103,6 +103,7 @@ struct InsightsView: View {
 
         weatherImpactCard(snapshot: snapshot)
         warningCard(snapshot: snapshot)
+        safetyPlanCard
         modelTransparencyCard(snapshot: snapshot)
         phenotypeCard(snapshot: snapshot)
         directionalCard(snapshot: snapshot)
@@ -226,12 +227,6 @@ struct InsightsView: View {
                         }
                     }
 
-                    Button("Open Safety Plan") {
-                        showingSafetyPlan = true
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .accessibilityIdentifier("open-safety-plan-button")
-
                     if let crisisText = safety.crisisBannerText {
                         Text(crisisText)
                             .font(.subheadline)
@@ -244,9 +239,35 @@ struct InsightsView: View {
         }
     }
 
+    private var safetyPlanCard: some View {
+        Button {
+            showingSafetyPlan = true
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "cross.case.fill")
+                    .font(.title3)
+                    .foregroundStyle(.red.opacity(0.85))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Safety Plan")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                    Text("Your warning signs, coping strategies, and contacts")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .accessibilityIdentifier("open-safety-plan-button")
+        .moodCard()
+    }
+
     private func weatherImpactCard(snapshot: InsightSnapshot) -> some View {
         Group {
-            if snapshot.weatherCoverageDays > 0 {
+            if snapshot.weatherCoverageDays >= 7 {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Weather & Mood")
                         .font(.headline)
@@ -270,6 +291,8 @@ struct InsightsView: View {
                                     .foregroundStyle(.secondary)
                             }
                         }
+                    } else {
+                        weatherGatheringHint("rain vs. clear sky")
                     }
 
                     if let hotDelta = snapshot.hotMoodDelta {
@@ -288,11 +311,23 @@ struct InsightsView: View {
                                     .foregroundStyle(.secondary)
                             }
                         }
+                    } else {
+                        weatherGatheringHint("hot vs. mild days")
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .moodCard()
             }
+        }
+    }
+
+    private func weatherGatheringHint(_ comparison: String) -> some View {
+        HStack(spacing: 8) {
+            Text("📊")
+                .font(.title2)
+            Text("Log a few more entries in different weather to see how \(comparison) affect your mood.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 


### PR DESCRIPTION
- Safety Plan toolbar button on HomeView (top-left, always visible)
- Safety Plan card on Insights (ungated from severity)
- Weather card suppressed below 7 days, gathering hints when deltas are nil