### PR TITLE
P1: Post-entry feedback, pattern stories, month comparison

### DIFF
--- a/moodbound/Views/InsightsView.swift
+++ b/moodbound/Views/InsightsView.swift
@@ -101,6 +101,8 @@ struct InsightsView: View {
             )
         }
 
+        yourPatternsCard(snapshot: snapshot)
+        monthOverMonthCard
         weatherImpactCard(snapshot: snapshot)
         warningCard(snapshot: snapshot)
         modelTransparencyCard(snapshot: snapshot)
@@ -242,6 +244,139 @@ struct InsightsView: View {
                 .moodCard()
             }
         }
+    }
+
+    private var monthOverMonthCard: some View {
+        let calendar = Calendar.current
+        let now = appNow
+
+        // Split entries into this-month (last 30d) and prior-month (31–60d ago).
+        let cutoff30 = calendar.date(byAdding: .day, value: -30, to: now) ?? now
+        let cutoff60 = calendar.date(byAdding: .day, value: -60, to: now) ?? now
+        let thisMonth = entries.filter { $0.timestamp >= cutoff30 && $0.timestamp <= now }
+        let lastMonth = entries.filter { $0.timestamp >= cutoff60 && $0.timestamp < cutoff30 }
+
+        return Group {
+            if thisMonth.count >= 5 && lastMonth.count >= 5 {
+                let thisAvg = Double(thisMonth.reduce(0) { $0 + $1.moodLevel }) / Double(thisMonth.count)
+                let lastAvg = Double(lastMonth.reduce(0) { $0 + $1.moodLevel }) / Double(lastMonth.count)
+                let delta = thisAvg - lastAvg
+
+                let thisSleep = thisMonth.reduce(0.0) { $0 + $1.sleepHours } / Double(thisMonth.count)
+                let lastSleep = lastMonth.reduce(0.0) { $0 + $1.sleepHours } / Double(lastMonth.count)
+                let sleepDelta = thisSleep - lastSleep
+
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "calendar.badge.clock")
+                            .foregroundStyle(.blue)
+                        Text("This Month vs Last")
+                            .font(.headline)
+                    }
+
+                    HStack(spacing: 20) {
+                        comparisonStat(
+                            label: "Avg Mood",
+                            delta: delta,
+                            format: { String(format: "%+.1f", $0) }
+                        )
+                        comparisonStat(
+                            label: "Avg Sleep",
+                            delta: sleepDelta,
+                            format: { String(format: "%+.1fh", $0) }
+                        )
+                        comparisonStat(
+                            label: "Entries",
+                            delta: Double(thisMonth.count - lastMonth.count),
+                            format: { String(format: "%+.0f", $0) }
+                        )
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .moodCard()
+            }
+        }
+    }
+
+    private func comparisonStat(label: String, delta: Double, format: (Double) -> String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 2) {
+                Image(systemName: delta > 0.05 ? "arrow.up.right" : delta < -0.05 ? "arrow.down.right" : "arrow.right")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(comparisonColor(delta))
+                Text(format(delta))
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(comparisonColor(delta))
+            }
+        }
+    }
+
+    private func comparisonColor(_ delta: Double) -> Color {
+        if abs(delta) < 0.05 { return .secondary }
+        return delta > 0 ? .green : .orange
+    }
+
+    private func yourPatternsCard(snapshot: InsightSnapshot) -> some View {
+        let stories = patternStories(snapshot: snapshot)
+        return Group {
+            if !stories.isEmpty {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "sparkle.magnifyingglass")
+                            .foregroundStyle(MoodboundDesign.tint)
+                        Text("Your Patterns")
+                            .font(.headline)
+                    }
+
+                    ForEach(stories, id: \.self) { story in
+                        Text(story)
+                            .font(.subheadline)
+                    }
+
+                    Text("Based on your logged data — patterns, not diagnoses.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .moodCard()
+            }
+        }
+    }
+
+    private func patternStories(snapshot: InsightSnapshot) -> [String] {
+        var stories: [String] = []
+
+        // Directional signal: "When your X changes, Y tends to follow."
+        if let probe = snapshot.directionalProbes.first, probe.confidence >= 0.3 {
+            let direction = probe.strength > 0 ? "rise" : "dip"
+            stories.append("When your \(probe.source.lowercased()) shifts, your \(probe.target.lowercased()) tends to \(direction) about \(probe.lagDays) day\(probe.lagDays == 1 ? "" : "s") later.")
+        }
+
+        // Top trigger: "X is your strongest mood-affecting trigger."
+        if let trigger = snapshot.triggerAttributions.first {
+            let direction = trigger.score > 0 ? "raising" : "lowering"
+            stories.append("\(trigger.triggerName) is your strongest trigger, \(direction) your mood when it shows up.")
+        }
+
+        // Medication trajectory
+        if let med = snapshot.medicationTrajectories.first(where: \.isDataSufficient) {
+            if med.shortWindowDelta < -0.1 {
+                stories.append("\(med.medicationName) seems to be helping — your stability is better on days you take it.")
+            } else if med.shortWindowDelta > 0.1 {
+                stories.append("\(med.medicationName) doesn't show a clear benefit yet in your data.")
+            }
+        }
+
+        // Sleep regularity from phenotype
+        if let sleepCard = snapshot.phenotypeCards.first(where: { $0.title.localizedCaseInsensitiveContains("sleep") }),
+           sleepCard.isSufficientData {
+            stories.append("Your sleep regularity is \(sleepCard.interpretationBand.lowercased()) right now.")
+        }
+
+        return stories
     }
 
     private func weatherImpactCard(snapshot: InsightSnapshot) -> some View {

--- a/moodbound/Views/InsightsView.swift
+++ b/moodbound/Views/InsightsView.swift
@@ -346,13 +346,24 @@ struct InsightsView: View {
         }
     }
 
+    // Map the jargon labels from DirectionalSignalService into natural prose.
+    private static let friendlyProbeLabels: [String: String] = [
+        "Sleep Deficit": "sleep drops",
+        "Next-Day Mood Elevation": "mood shifts upward",
+        "Trigger Load": "trigger load rises",
+        "Next-Day Anxiety": "anxiety increases",
+        "Medication Adherence": "you take your meds consistently",
+        "Next-Day Volatility (inverse)": "your stability improves",
+    ]
+
     private func patternStories(snapshot: InsightSnapshot) -> [String] {
         var stories: [String] = []
 
-        // Directional signal: "When your X changes, Y tends to follow."
+        // Directional signal: "When your sleep drops, your mood tends to shift upward ~1 day later."
         if let probe = snapshot.directionalProbes.first, probe.confidence >= 0.3 {
-            let direction = probe.strength > 0 ? "rise" : "dip"
-            stories.append("When your \(probe.source.lowercased()) shifts, your \(probe.target.lowercased()) tends to \(direction) about \(probe.lagDays) day\(probe.lagDays == 1 ? "" : "s") later.")
+            let source = Self.friendlyProbeLabels[probe.source] ?? probe.source.lowercased()
+            let target = Self.friendlyProbeLabels[probe.target] ?? probe.target.lowercased()
+            stories.append("When your \(source), your \(target) about \(probe.lagDays) day\(probe.lagDays == 1 ? "" : "s") later.")
         }
 
         // Top trigger: "X is your strongest mood-affecting trigger."

--- a/moodbound/Views/NewEntryView.swift
+++ b/moodbound/Views/NewEntryView.swift
@@ -27,6 +27,7 @@ struct NewEntryView: View {
     @State private var newlyAddedTriggers: Set<String> = []
     @State private var showingSaveError = false
     @State private var saveErrorMessage = ""
+    @State private var savedFeedback: SavedFeedback?
     @State private var didApplyDefaults = false
     @State private var currentWeather: OpenMeteoWeatherService.CurrentWeather?
     @State private var weatherStatus: WeatherFetchStatus = .idle
@@ -318,6 +319,13 @@ struct NewEntryView: View {
             } message: {
                 Text(saveErrorMessage)
             }
+            .overlay {
+                if let feedback = savedFeedback {
+                    savedFeedbackOverlay(feedback)
+                        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                }
+            }
+            .animation(.easeOut(duration: 0.25), value: savedFeedback != nil)
         }
     }
 
@@ -393,7 +401,19 @@ struct NewEntryView: View {
                 }
             }
 
-            dismiss()
+            // Show brief feedback before dismissing so the user knows
+            // the entry mattered — streak, outlook, and a one-liner.
+            let feedback = buildSavedFeedback()
+            if entryToEdit != nil {
+                // Edits don't need the feedback flourish.
+                dismiss()
+            } else {
+                savedFeedback = feedback
+                Task {
+                    try? await Task.sleep(for: .seconds(1.5))
+                    dismiss()
+                }
+            }
         } catch {
             AppLogger.error("Failed to save mood entry", error: error)
             saveErrorMessage = error.localizedDescription
@@ -776,6 +796,66 @@ struct NewEntryView: View {
         default: return "🌡️"
         }
     }
+
+    private func buildSavedFeedback() -> SavedFeedback {
+        let vm = MoodViewModel()
+        let now = AppClock.now
+        let streak = vm.streakDays(entries: recentEntries, now: now)
+
+        // Compute a lightweight outlook if we have enough data.
+        var outlookPct: Int?
+        if recentEntries.count >= 3 {
+            let snapshot = InsightEngine.snapshot(entries: Array(recentEntries), now: now)
+            let risk = snapshot.safety.posteriorRisk
+            outlookPct = Int((risk * 100).rounded())
+        }
+
+        let message: String
+        if streak > 1 {
+            message = "\(streak)-day streak. Keep it going."
+        } else {
+            message = "First entry in a while. Good to see you."
+        }
+
+        return SavedFeedback(streakDays: streak, outlookPct: outlookPct, message: message)
+    }
+
+    @ViewBuilder
+    private func savedFeedbackOverlay(_ feedback: SavedFeedback) -> some View {
+        ZStack {
+            Color(.systemBackground).opacity(0.92)
+                .ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.green)
+
+                Text("Logged")
+                    .font(.title2.weight(.bold))
+
+                if let pct = feedback.outlookPct {
+                    Text("7-day outlook: \(pct)%")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(feedback.message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(32)
+        }
+        .onTapGesture { dismiss() }
+        .accessibilityLabel("Entry saved. \(feedback.message)")
+    }
+}
+
+struct SavedFeedback {
+    let streakDays: Int
+    let outlookPct: Int?
+    let message: String
 }
 
 enum WeatherFetchStatus {

--- a/moodbound/Views/NewEntryView.swift
+++ b/moodbound/Views/NewEntryView.swift
@@ -403,7 +403,7 @@ struct NewEntryView: View {
 
             // Show brief feedback before dismissing so the user knows
             // the entry mattered — streak, outlook, and a one-liner.
-            let feedback = buildSavedFeedback()
+            let feedback = buildSavedFeedback(including: entry)
             if entryToEdit != nil {
                 // Edits don't need the feedback flourish.
                 dismiss()
@@ -797,15 +797,19 @@ struct NewEntryView: View {
         }
     }
 
-    private func buildSavedFeedback() -> SavedFeedback {
+    private func buildSavedFeedback(including newEntry: MoodEntry) -> SavedFeedback {
         let vm = MoodViewModel()
         let now = AppClock.now
-        let streak = vm.streakDays(entries: recentEntries, now: now)
+        // recentEntries is a @Query that won't refresh until the next view
+        // update cycle, so it doesn't include the entry we just saved.
+        // Prepend it manually so streak and outlook reflect the new entry.
+        let allEntries = [newEntry] + recentEntries
+        let streak = vm.streakDays(entries: allEntries, now: now)
 
         // Compute a lightweight outlook if we have enough data.
         var outlookPct: Int?
-        if recentEntries.count >= 3 {
-            let snapshot = InsightEngine.snapshot(entries: Array(recentEntries), now: now)
+        if allEntries.count >= 3 {
+            let snapshot = InsightEngine.snapshot(entries: allEntries, now: now)
             let risk = snapshot.safety.posteriorRisk
             outlookPct = Int((risk * 100).rounded())
         }


### PR DESCRIPTION
- Post-entry feedback overlay (streak + outlook) after saving
- "Your Patterns" card with plain-language stories from engine output
- "This Month vs Last" comparison card on Insights