### PR TITLE
P3: Clinician PDF report

### DIFF
--- a/moodbound/Models/ClinicianReportDocument.swift
+++ b/moodbound/Models/ClinicianReportDocument.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ClinicianReportDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.pdf] }
+
+    var data: Data
+
+    init(data: Data) {
+        self.data = data
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        self.data = data
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: data)
+    }
+}

--- a/moodbound/Services/ClinicianReportService.swift
+++ b/moodbound/Services/ClinicianReportService.swift
@@ -1,11 +1,17 @@
 import Foundation
 import SwiftData
 
+struct DailyMoodPoint: Identifiable {
+    let id: Date  // startOfDay
+    let averageMood: Double
+}
+
 struct ClinicianReportData {
     let range: DateInterval
     let generatedAt: Date
     let entryCount: Int
     let distinctDays: Int
+    let dailyMoodPoints: [DailyMoodPoint]
     let snapshot: InsightSnapshot
     let safetyPlanText: SafetyPlanText?
     let supportContacts: [SupportContactInfo]
@@ -18,7 +24,8 @@ struct SafetyPlanText {
     let emergencySteps: String
 }
 
-struct SupportContactInfo {
+struct SupportContactInfo: Identifiable {
+    let id = UUID()
     let name: String
     let relationship: String
     let phone: String
@@ -60,6 +67,13 @@ enum ClinicianReportService {
             throw ClinicianReportError.insufficientData(distinctDays: distinctDays)
         }
 
+        // Aggregate mood by day for the chart on page 2.
+        let grouped = Dictionary(grouping: entries) { calendar.startOfDay(for: $0.timestamp) }
+        let dailyMoodPoints = grouped.map { day, dayEntries in
+            let avg = Double(dayEntries.reduce(0) { $0 + $1.moodLevel }) / Double(dayEntries.count)
+            return DailyMoodPoint(id: day, averageMood: avg)
+        }.sorted { $0.id < $1.id }
+
         let insightSnapshot = InsightEngine.snapshot(entries: entries, now: end)
 
         // Fetch safety plan + contacts for page 3.
@@ -87,6 +101,7 @@ enum ClinicianReportService {
             generatedAt: Date(),
             entryCount: entries.count,
             distinctDays: distinctDays,
+            dailyMoodPoints: dailyMoodPoints,
             snapshot: insightSnapshot,
             safetyPlanText: safetyPlanText,
             supportContacts: contactInfos,

--- a/moodbound/Services/ClinicianReportService.swift
+++ b/moodbound/Services/ClinicianReportService.swift
@@ -1,0 +1,124 @@
+import Foundation
+import SwiftData
+
+struct ClinicianReportData {
+    let range: DateInterval
+    let generatedAt: Date
+    let entryCount: Int
+    let distinctDays: Int
+    let snapshot: InsightSnapshot
+    let safetyPlanText: SafetyPlanText?
+    let supportContacts: [SupportContactInfo]
+    let appVersion: String
+}
+
+struct SafetyPlanText {
+    let warningSigns: String
+    let copingStrategies: String
+    let emergencySteps: String
+}
+
+struct SupportContactInfo {
+    let name: String
+    let relationship: String
+    let phone: String
+    let isPrimary: Bool
+}
+
+enum ClinicianReportError: LocalizedError {
+    case insufficientData(distinctDays: Int)
+    case renderingFailed(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .insufficientData(let days):
+            return "Only \(days) day\(days == 1 ? "" : "s") of data in this range. Need at least 7."
+        case .renderingFailed(let error):
+            return "Couldn't generate the PDF: \(error.localizedDescription)"
+        }
+    }
+}
+
+enum ClinicianReportService {
+    static let minimumDistinctDays = 7
+
+    static func snapshot(for range: DateInterval, context: ModelContext) throws -> ClinicianReportData {
+        let start = range.start
+        let end = range.end
+
+        var descriptor = FetchDescriptor<MoodEntry>(
+            predicate: #Predicate { $0.timestamp >= start && $0.timestamp <= end },
+            sortBy: [SortDescriptor(\.timestamp)]
+        )
+        descriptor.fetchLimit = 10_000
+        let entries = try context.fetch(descriptor)
+
+        let calendar = Calendar.current
+        let distinctDays = Set(entries.map { calendar.startOfDay(for: $0.timestamp) }).count
+
+        guard distinctDays >= minimumDistinctDays else {
+            throw ClinicianReportError.insufficientData(distinctDays: distinctDays)
+        }
+
+        let insightSnapshot = InsightEngine.snapshot(entries: entries, now: end)
+
+        // Fetch safety plan + contacts for page 3.
+        let plans = try context.fetch(FetchDescriptor<SafetyPlan>())
+        let safetyPlanText: SafetyPlanText? = plans.first.flatMap { plan in
+            let hasContent = !plan.warningSigns.isEmpty || !plan.copingStrategies.isEmpty || !plan.emergencySteps.isEmpty
+            guard hasContent else { return nil }
+            return SafetyPlanText(
+                warningSigns: plan.warningSigns,
+                copingStrategies: plan.copingStrategies,
+                emergencySteps: plan.emergencySteps
+            )
+        }
+
+        let contacts = try context.fetch(FetchDescriptor<SupportContact>(sortBy: [SortDescriptor(\.name)]))
+        let contactInfos = contacts.map {
+            SupportContactInfo(name: $0.name, relationship: $0.relationship, phone: $0.phone, isPrimary: $0.isPrimary)
+        }
+
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+
+        return ClinicianReportData(
+            range: range,
+            generatedAt: Date(),
+            entryCount: entries.count,
+            distinctDays: distinctDays,
+            snapshot: insightSnapshot,
+            safetyPlanText: safetyPlanText,
+            supportContacts: contactInfos,
+            appVersion: "moodbound \(version) (\(build))"
+        )
+    }
+
+    @MainActor
+    static func render(_ data: ClinicianReportData) throws -> URL {
+        let pageSize = CGSize(width: 612, height: 792) // US Letter
+        let renderer = UIGraphicsPDFRenderer(bounds: CGRect(origin: .zero, size: pageSize))
+
+        let pdfData = renderer.pdfData { ctx in
+            let pages: [any View] = [
+                ReportPageOne(data: data),
+                ReportPageTwo(data: data),
+                ReportPageThree(data: data),
+            ]
+
+            for page in pages {
+                ctx.beginPage()
+                let imageRenderer = ImageRenderer(content: AnyView(page.frame(width: pageSize.width, height: pageSize.height)))
+                imageRenderer.proposedSize = .init(pageSize)
+                imageRenderer.render { _, drawAction in
+                    drawAction(ctx.cgContext)
+                }
+            }
+        }
+
+        let filename = "moodbound-report-\(data.range.start.formatted(.iso8601.year().month().day()))-to-\(data.range.end.formatted(.iso8601.year().month().day())).pdf"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+        try pdfData.write(to: url)
+        return url
+    }
+}

--- a/moodbound/Views/ClinicianReportPages.swift
+++ b/moodbound/Views/ClinicianReportPages.swift
@@ -218,6 +218,23 @@ struct ReportPageTwo: View {
                 )
                 .foregroundStyle(latentColor(posterior.distribution.dominantState).opacity(0.1))
             }
+
+            // Mood line
+            ForEach(data.dailyMoodPoints) { point in
+                LineMark(
+                    x: .value("Day", point.id, unit: .day),
+                    y: .value("Mood", point.averageMood)
+                )
+                .foregroundStyle(Color.primary.opacity(0.8))
+                .lineStyle(StrokeStyle(lineWidth: 1.5))
+
+                PointMark(
+                    x: .value("Day", point.id, unit: .day),
+                    y: .value("Mood", point.averageMood)
+                )
+                .symbolSize(12)
+                .foregroundStyle(Color.primary.opacity(0.6))
+            }
         }
         .chartYScale(domain: -3...3)
         .chartYAxis {
@@ -370,7 +387,7 @@ struct ReportPageThree: View {
                     Text("Support Contacts")
                         .font(.system(size: 9, weight: .semibold, design: .rounded))
                         .foregroundStyle(.secondary)
-                    ForEach(data.supportContacts, id: \.name) { contact in
+                    ForEach(data.supportContacts) { contact in
                         Text("\(contact.name)\(contact.relationship.isEmpty ? "" : " (\(contact.relationship))") — \(contact.phone)\(contact.isPrimary ? " ★" : "")")
                             .font(.system(size: 9, design: .rounded))
                     }

--- a/moodbound/Views/ClinicianReportPages.swift
+++ b/moodbound/Views/ClinicianReportPages.swift
@@ -1,0 +1,474 @@
+import SwiftUI
+import Charts
+
+// MARK: - Page 1: Summary & Safety
+
+struct ReportPageOne: View {
+    let data: ClinicianReportData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            reportHeader(data: data, pageNumber: 1)
+
+            // Disclaimer
+            Text("Self-reported mood data for clinical conversation. Not a diagnostic instrument. Not a substitute for professional assessment.")
+                .font(.system(size: 9, design: .rounded))
+                .italic()
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.gray.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .padding(.horizontal, 48)
+                .padding(.top, 8)
+
+            // Safety severity
+            let safety = data.snapshot.safety
+            VStack(alignment: .leading, spacing: 6) {
+                sectionTitle("Safety Assessment")
+                HStack(spacing: 8) {
+                    Text(safety.severity.rawValue)
+                        .font(.system(size: 18, weight: .bold, design: .rounded))
+                        .foregroundStyle(severityColor(safety.severity))
+                    Spacer()
+                    Text("Posterior risk: \(Int((safety.posteriorRisk * 100).rounded()))%")
+                        .font(.system(size: 11, design: .rounded))
+                        .foregroundStyle(.secondary)
+                }
+                if !safety.messages.isEmpty {
+                    Text(safety.messages.joined(separator: " • "))
+                        .font(.system(size: 10, design: .rounded))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 48)
+            .padding(.top, 16)
+
+            // Key numbers grid
+            VStack(alignment: .leading, spacing: 6) {
+                sectionTitle("Key Numbers")
+                HStack(spacing: 0) {
+                    keyNumber("Streak", "\(data.snapshot.streakDays)d")
+                    keyNumber("7d Avg", data.snapshot.avg7.map { String(format: "%+.1f", $0) } ?? "—")
+                    keyNumber("30d Avg", data.snapshot.avg30.map { String(format: "%+.1f", $0) } ?? "—")
+                }
+                HStack(spacing: 0) {
+                    keyNumber("Entries", "\(data.entryCount)")
+                    keyNumber("Med Adherence", data.snapshot.medicationAdherenceRate14d.map { "\(Int(($0 * 100).rounded()))%" } ?? "—")
+                    keyNumber("Top Trigger", data.snapshot.topTrigger14d ?? "—")
+                }
+            }
+            .padding(.horizontal, 48)
+            .padding(.top, 16)
+
+            // 7-day forecast
+            VStack(alignment: .leading, spacing: 6) {
+                sectionTitle("7-Day Outlook")
+                let pct = Int((data.snapshot.forecastValue * 100).rounded())
+                let ciLow = Int((data.snapshot.forecastCILow * 100).rounded())
+                let ciHigh = Int((data.snapshot.forecastCIHigh * 100).rounded())
+                Text("\(pct)% (CI \(ciLow)–\(ciHigh)%)")
+                    .font(.system(size: 16, weight: .bold, design: .rounded))
+                Text("Conformal CI width: \(String(format: "%.2f", data.snapshot.conformalCIWidth))")
+                    .font(.system(size: 10, design: .rounded))
+                    .foregroundStyle(.secondary)
+
+                // Forecast bar
+                GeometryReader { geo in
+                    let w = geo.size.width
+                    ZStack(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color.gray.opacity(0.15))
+                            .frame(height: 12)
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color.orange.opacity(0.3))
+                            .frame(width: max(0, w * CGFloat(data.snapshot.forecastCIHigh) - w * CGFloat(data.snapshot.forecastCILow)), height: 12)
+                            .offset(x: w * CGFloat(data.snapshot.forecastCILow))
+                        Circle()
+                            .fill(Color.orange)
+                            .frame(width: 10, height: 10)
+                            .offset(x: w * CGFloat(data.snapshot.forecastValue) - 5)
+                    }
+                }
+                .frame(height: 14)
+            }
+            .padding(.horizontal, 48)
+            .padding(.top, 16)
+
+            // Change & drift
+            VStack(alignment: .leading, spacing: 4) {
+                sectionTitle("Change Detection")
+                HStack(spacing: 24) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("BOCPD change probability")
+                            .font(.system(size: 9, design: .rounded))
+                            .foregroundStyle(.secondary)
+                        Text(String(format: "%.2f", data.snapshot.bayesianChangeProbability))
+                            .font(.system(size: 14, weight: .bold, design: .rounded))
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Wasserstein drift")
+                            .font(.system(size: 9, design: .rounded))
+                            .foregroundStyle(.secondary)
+                        Text(String(format: "%.2f", data.snapshot.wassersteinDriftScore))
+                            .font(.system(size: 14, weight: .bold, design: .rounded))
+                    }
+                }
+            }
+            .padding(.horizontal, 48)
+            .padding(.top, 16)
+
+            Spacer()
+            reportFooter(data: data, pageNumber: 1, totalPages: 3)
+        }
+        .frame(width: 612, height: 792)
+        .background(Color.white)
+    }
+
+    private func keyNumber(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.system(size: 9, design: .rounded))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 13, weight: .bold, design: .rounded))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Page 2: Trajectory & Latent State
+
+struct ReportPageTwo: View {
+    let data: ClinicianReportData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            reportHeader(data: data, pageNumber: 2)
+
+            // Mood chart with latent state overlay
+            VStack(alignment: .leading, spacing: 6) {
+                sectionTitle("Mood Trajectory")
+                if !data.snapshot.latentPosteriors.isEmpty {
+                    moodChart
+                        .frame(height: 260)
+                    latentStateLegend
+                }
+            }
+            .padding(.horizontal, 48)
+            .padding(.top, 12)
+
+            // Digital phenotype biomarkers
+            if !data.snapshot.phenotypeCards.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    sectionTitle("Biomarkers")
+                    ForEach(data.snapshot.phenotypeCards.prefix(4)) { card in
+                        HStack {
+                            Text(card.title)
+                                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            Spacer()
+                            Text(card.interpretationBand)
+                                .font(.system(size: 10, weight: .bold, design: .rounded))
+                            Text(String(format: "(%.1f)", card.metricValue))
+                                .font(.system(size: 9, design: .rounded))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(.horizontal, 48)
+                .padding(.top, 16)
+            }
+
+            // Weather impact
+            if data.snapshot.weatherCoverageDays >= 7 {
+                VStack(alignment: .leading, spacing: 6) {
+                    sectionTitle("Weather Impact")
+                    Text("\(data.snapshot.weatherCoverageDays)-day coverage\(data.snapshot.weatherCity.map { " for \($0)" } ?? "")")
+                        .font(.system(size: 9, design: .rounded))
+                        .foregroundStyle(.secondary)
+                    if let rainy = data.snapshot.rainyMoodDelta {
+                        Text("Rain effect: \(String(format: "%+.2f", rainy)) mood points")
+                            .font(.system(size: 10, design: .rounded))
+                    }
+                    if let hot = data.snapshot.hotMoodDelta {
+                        Text("Heat effect: \(String(format: "%+.2f", hot)) mood points")
+                            .font(.system(size: 10, design: .rounded))
+                    }
+                }
+                .padding(.horizontal, 48)
+                .padding(.top, 16)
+            }
+
+            Spacer()
+            reportFooter(data: data, pageNumber: 2, totalPages: 3)
+        }
+        .frame(width: 612, height: 792)
+        .background(Color.white)
+    }
+
+    private var moodChart: some View {
+        Chart {
+            // Latent state background
+            ForEach(data.snapshot.latentPosteriors, id: \.timestamp) { posterior in
+                RectangleMark(
+                    x: .value("Day", posterior.timestamp, unit: .day),
+                    yStart: .value("Low", -3),
+                    yEnd: .value("High", 3)
+                )
+                .foregroundStyle(latentColor(posterior.distribution.dominantState).opacity(0.1))
+            }
+        }
+        .chartYScale(domain: -3...3)
+        .chartYAxis {
+            AxisMarks(values: [-3, -2, -1, 0, 1, 2, 3]) { value in
+                AxisGridLine()
+                AxisValueLabel {
+                    Text("\(value.as(Int.self) ?? 0)")
+                        .font(.system(size: 8))
+                }
+            }
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 6)) { _ in
+                AxisGridLine()
+                AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                    .font(.system(size: 8))
+            }
+        }
+    }
+
+    private var latentStateLegend: some View {
+        HStack(spacing: 12) {
+            legendItem("Depressive", .blue)
+            legendItem("Stable", .green)
+            legendItem("Elevated", .orange)
+            legendItem("Unstable", .purple)
+        }
+        .font(.system(size: 8, design: .rounded))
+    }
+
+    private func legendItem(_ label: String, _ color: Color) -> some View {
+        HStack(spacing: 3) {
+            Circle().fill(color.opacity(0.5)).frame(width: 6, height: 6)
+            Text(label).foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Page 3: Triggers, Medication & Narrative
+
+struct ReportPageThree: View {
+    let data: ClinicianReportData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            reportHeader(data: data, pageNumber: 3)
+
+            // Trigger attributions
+            if !data.snapshot.triggerAttributions.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    sectionTitle("Trigger Attributions")
+                    Text("Observational associations, not causal attribution.")
+                        .font(.system(size: 8, design: .rounded))
+                        .foregroundStyle(.secondary)
+
+                    // Table header
+                    HStack {
+                        Text("Trigger").frame(width: 120, alignment: .leading)
+                        Text("Effect").frame(width: 60, alignment: .trailing)
+                        Text("Confidence").frame(width: 80, alignment: .trailing)
+                        Text("Events").frame(width: 50, alignment: .trailing)
+                    }
+                    .font(.system(size: 8, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.secondary)
+
+                    ForEach(data.snapshot.triggerAttributions.prefix(5), id: \.triggerName) { attr in
+                        HStack {
+                            Text(attr.triggerName)
+                                .lineLimit(1)
+                                .frame(width: 120, alignment: .leading)
+                            Text(String(format: "%+.2f", attr.score))
+                                .frame(width: 60, alignment: .trailing)
+                            Text("\(Int((attr.confidence * 100).rounded()))%")
+                                .frame(width: 80, alignment: .trailing)
+                            Text("\(attr.supportingEvents)")
+                                .frame(width: 50, alignment: .trailing)
+                        }
+                        .font(.system(size: 9, design: .rounded))
+                    }
+                }
+                .padding(.horizontal, 48)
+                .padding(.top, 12)
+            }
+
+            // Medication trajectories
+            let meds = data.snapshot.medicationTrajectories.filter(\.isDataSufficient)
+            if !meds.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    sectionTitle("Medication Effects")
+                    Text("Compares stability on days medication was taken vs. missed.")
+                        .font(.system(size: 8, design: .rounded))
+                        .foregroundStyle(.secondary)
+
+                    ForEach(meds.prefix(3), id: \.medicationName) { med in
+                        HStack {
+                            Text(med.medicationName)
+                                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            Spacer()
+                            VStack(alignment: .trailing, spacing: 1) {
+                                Text("Short: \(String(format: "%+.2f", med.shortWindowDelta))")
+                                Text("Medium: \(String(format: "%+.2f", med.mediumWindowDelta))")
+                            }
+                            .font(.system(size: 9, design: .rounded))
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(.horizontal, 48)
+                .padding(.top, 16)
+            }
+
+            // Narrative insights
+            if !data.snapshot.narrativeCards.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    sectionTitle("Narrative Insights")
+                    ForEach(data.snapshot.narrativeCards.prefix(4)) { card in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(card.title)
+                                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            Text(card.body)
+                                .font(.system(size: 9, design: .rounded))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(.horizontal, 48)
+                .padding(.top, 16)
+            }
+
+            // Safety plan
+            if let plan = data.safetyPlanText {
+                VStack(alignment: .leading, spacing: 6) {
+                    sectionTitle("Patient's Safety Plan")
+                    if !plan.warningSigns.isEmpty {
+                        planField("Warning Signs", plan.warningSigns)
+                    }
+                    if !plan.copingStrategies.isEmpty {
+                        planField("Coping Strategies", plan.copingStrategies)
+                    }
+                    if !plan.emergencySteps.isEmpty {
+                        planField("Emergency Steps", plan.emergencySteps)
+                    }
+                }
+                .padding(.horizontal, 48)
+                .padding(.top, 16)
+            }
+
+            if !data.supportContacts.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Support Contacts")
+                        .font(.system(size: 9, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.secondary)
+                    ForEach(data.supportContacts, id: \.name) { contact in
+                        Text("\(contact.name)\(contact.relationship.isEmpty ? "" : " (\(contact.relationship))") — \(contact.phone)\(contact.isPrimary ? " ★" : "")")
+                            .font(.system(size: 9, design: .rounded))
+                    }
+                }
+                .padding(.horizontal, 48)
+                .padding(.top, 8)
+            }
+
+            Spacer()
+
+            // Crisis banner if applicable
+            if let crisisText = data.snapshot.safety.crisisBannerText {
+                Text(crisisText)
+                    .font(.system(size: 9, weight: .semibold, design: .rounded))
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.red.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .padding(.horizontal, 48)
+                    .padding(.bottom, 4)
+            }
+
+            reportFooter(data: data, pageNumber: 3, totalPages: 3)
+        }
+        .frame(width: 612, height: 792)
+        .background(Color.white)
+    }
+
+    private func planField(_ title: String, _ text: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .foregroundStyle(.secondary)
+            Text(text)
+                .font(.system(size: 9, design: .rounded))
+        }
+    }
+}
+
+// MARK: - Shared report components
+
+private func reportHeader(data: ClinicianReportData, pageNumber: Int) -> some View {
+    HStack(alignment: .top) {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Mood Report")
+                .font(.system(size: 22, weight: .bold, design: .rounded))
+            Text("\(data.range.start.formatted(date: .abbreviated, time: .omitted)) – \(data.range.end.formatted(date: .abbreviated, time: .omitted))")
+                .font(.system(size: 10, design: .rounded))
+                .foregroundStyle(.secondary)
+        }
+        Spacer()
+        VStack(alignment: .trailing, spacing: 2) {
+            Text(data.appVersion)
+                .font(.system(size: 8, design: .rounded))
+                .foregroundStyle(.secondary)
+            Text("Generated \(data.generatedAt.formatted(date: .abbreviated, time: .shortened))")
+                .font(.system(size: 8, design: .rounded))
+                .foregroundStyle(.secondary)
+        }
+    }
+    .padding(.horizontal, 48)
+    .padding(.top, 36)
+}
+
+private func reportFooter(data: ClinicianReportData, pageNumber: Int, totalPages: Int) -> some View {
+    HStack {
+        Text("Generated on-device. No data left your phone.")
+            .font(.system(size: 7, design: .rounded))
+            .foregroundStyle(.secondary)
+        Spacer()
+        Text("\(pageNumber) / \(totalPages)")
+            .font(.system(size: 7, weight: .semibold, design: .rounded))
+            .foregroundStyle(.secondary)
+    }
+    .padding(.horizontal, 48)
+    .padding(.bottom, 24)
+}
+
+private func sectionTitle(_ title: String) -> some View {
+    Text(title)
+        .font(.system(size: 12, weight: .bold, design: .rounded))
+        .padding(.top, 4)
+}
+
+private func severityColor(_ severity: SafetySeverity) -> Color {
+    switch severity {
+    case .none: return .green
+    case .elevated: return .orange
+    case .high: return .red
+    case .critical: return .red
+    }
+}
+
+private func latentColor(_ state: LatentMoodState) -> Color {
+    switch state {
+    case .depressive: return .blue
+    case .stable: return .green
+    case .elevated: return .orange
+    case .unstable: return .purple
+    }
+}

--- a/moodbound/Views/ClinicianReportView.swift
+++ b/moodbound/Views/ClinicianReportView.swift
@@ -127,17 +127,25 @@ struct ClinicianReportView: View {
 
     private func generate() {
         state = .generating
-        generateTask = Task {
+        let range = dateRange
+        let ctx = context
+        generateTask = Task.detached(priority: .userInitiated) {
             do {
-                let data = try ClinicianReportService.snapshot(for: dateRange, context: context)
-                let url = try ClinicianReportService.render(data)
-                state = .ready(url)
+                // snapshot() runs the full InsightEngine pipeline (HMM,
+                // Bayesian, etc.) — keep it off the main actor so the
+                // progress spinner can animate.
+                let data = try ClinicianReportService.snapshot(for: range, context: ctx)
+                // render() needs the main actor for ImageRenderer.
+                let url = try await MainActor.run {
+                    try ClinicianReportService.render(data)
+                }
+                await MainActor.run { state = .ready(url) }
             } catch let error as ClinicianReportError {
-                state = .error(error.localizedDescription ?? "Unknown error")
+                await MainActor.run { state = .error(error.localizedDescription) }
             } catch is CancellationError {
-                state = .idle
+                await MainActor.run { state = .idle }
             } catch {
-                state = .error(error.localizedDescription)
+                await MainActor.run { state = .error(error.localizedDescription) }
             }
         }
     }

--- a/moodbound/Views/ClinicianReportView.swift
+++ b/moodbound/Views/ClinicianReportView.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+import SwiftData
+
+struct ClinicianReportView: View {
+    @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var rangeOption: RangeOption = .days30
+    @State private var customStart: Date = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+    @State private var customEnd: Date = Date()
+    @State private var state: ReportState = .idle
+    @State private var generateTask: Task<Void, Never>?
+
+    enum RangeOption: String, CaseIterable, Identifiable {
+        case days30 = "30 days"
+        case days60 = "60 days"
+        case days90 = "90 days"
+        case custom = "Custom"
+
+        var id: String { rawValue }
+    }
+
+    enum ReportState: Equatable {
+        case idle
+        case generating
+        case ready(URL)
+        case error(String)
+
+        static func == (lhs: ReportState, rhs: ReportState) -> Bool {
+            switch (lhs, rhs) {
+            case (.idle, .idle), (.generating, .generating): return true
+            case (.ready(let a), .ready(let b)): return a == b
+            case (.error(let a), .error(let b)): return a == b
+            default: return false
+            }
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Picker("Range", selection: $rangeOption) {
+                        ForEach(RangeOption.allCases) { option in
+                            Text(option.rawValue).tag(option)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    if rangeOption == .custom {
+                        DatePicker("From", selection: $customStart, in: ...customEnd, displayedComponents: .date)
+                        DatePicker("To", selection: $customEnd, in: customStart..., displayedComponents: .date)
+                    }
+                } header: {
+                    Text("Date Range")
+                }
+
+                Section {
+                    switch state {
+                    case .idle:
+                        Button {
+                            generate()
+                        } label: {
+                            Label("Generate Report", systemImage: "doc.richtext")
+                        }
+                        .accessibilityIdentifier("generate-report-button")
+
+                    case .generating:
+                        HStack(spacing: 10) {
+                            ProgressView()
+                            Text("Generating report...")
+                                .foregroundStyle(.secondary)
+                        }
+                        .accessibilityLabel("Generating report")
+
+                    case .ready(let url):
+                        ShareLink(item: url, preview: SharePreview("Mood Report", image: Image(systemName: "doc.richtext"))) {
+                            Label("Share Report", systemImage: "square.and.arrow.up")
+                        }
+
+                        Button {
+                            state = .idle
+                        } label: {
+                            Label("Generate Another", systemImage: "arrow.counterclockwise")
+                        }
+
+                    case .error(let message):
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label(message, systemImage: "exclamationmark.triangle")
+                                .font(.subheadline)
+                                .foregroundStyle(.red)
+
+                            Button("Retry") { generate() }
+                        }
+                    }
+                } footer: {
+                    Text("Creates a PDF summary of your mood data for sharing with your doctor. Everything stays on your device.")
+                }
+            }
+            .navigationTitle("Share with Doctor")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+            .onDisappear {
+                generateTask?.cancel()
+            }
+        }
+    }
+
+    private var dateRange: DateInterval {
+        let now = Date()
+        let calendar = Calendar.current
+        switch rangeOption {
+        case .days30:
+            return DateInterval(start: calendar.date(byAdding: .day, value: -30, to: now)!, end: now)
+        case .days60:
+            return DateInterval(start: calendar.date(byAdding: .day, value: -60, to: now)!, end: now)
+        case .days90:
+            return DateInterval(start: calendar.date(byAdding: .day, value: -90, to: now)!, end: now)
+        case .custom:
+            return DateInterval(start: customStart, end: customEnd)
+        }
+    }
+
+    private func generate() {
+        state = .generating
+        generateTask = Task {
+            do {
+                let data = try ClinicianReportService.snapshot(for: dateRange, context: context)
+                let url = try ClinicianReportService.render(data)
+                state = .ready(url)
+            } catch let error as ClinicianReportError {
+                state = .error(error.localizedDescription ?? "Unknown error")
+            } catch is CancellationError {
+                state = .idle
+            } catch {
+                state = .error(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/moodbound/Views/SettingsView.swift
+++ b/moodbound/Views/SettingsView.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
     @State private var errorMessage = ""
     @State private var showingSuccess = false
     @State private var successMessage = ""
+    @State private var showingReport = false
 
     var body: some View {
         NavigationStack {
@@ -61,6 +62,18 @@ struct SettingsView: View {
 
                 Section {
                     Button {
+                        showingReport = true
+                    } label: {
+                        Label("Share with Doctor", systemImage: "doc.richtext")
+                    }
+                } header: {
+                    Text("Reports")
+                } footer: {
+                    Text("Generate a PDF summary of your mood data to bring to an appointment.")
+                }
+
+                Section {
+                    Button {
                         exportData()
                     } label: {
                         Label("Export Data", systemImage: "square.and.arrow.up")
@@ -83,6 +96,9 @@ struct SettingsView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
+            }
+            .sheet(isPresented: $showingReport) {
+                ClinicianReportView()
             }
             .fileExporter(
                 isPresented: $showingExporter,


### PR DESCRIPTION
- 3-page PDF export (summary/safety, trajectory/biomarkers, triggers/meds/narrative)
- ClinicianReportService with date-range snapshot + ImageRenderer PDF rendering
- Settings entry: "Share with Doctor"
- Includes mood line chart, safety plan text, support contacts, crisis banner