### PR TITLE
docs: update App Store link and add marketing site reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Mood tracking built for bipolar disorder. Reads your body through Apple Health, detects pattern shifts with Bayesian models, warns you when something is changing.
 
-On-device. Open source. [$2.99 on the App Store.](https://apps.apple.com/app/moodbound)
+On-device. Open source. [Free on the App Store.](https://apps.apple.com/us/app/moodbound/id6752506815)
+
+Learn more at [moodbound.app](https://moodbound.app). Site source: [Evoke4350/moodbound.app](https://github.com/Evoke4350/moodbound.app).
 
 ![Swift](https://img.shields.io/badge/Swift-5.9-orange) ![iOS](https://img.shields.io/badge/iOS-17.0%2B-blue) ![License](https://img.shields.io/badge/License-MIT-green) ![HealthKit](https://img.shields.io/badge/HealthKit-Integrated-red)
 
@@ -103,4 +105,4 @@ The source code is public. Read it.
 
 MIT. See [LICENSE](LICENSE).
 
-Open source code, $2.99 on the App Store. You pay for the signed build, the updates, and not having to compile it yourself.
+Free on the App Store, or build from source. Both are fully MIT-licensed.


### PR DESCRIPTION
## Summary
- Update the App Store link to the real listing (`https://apps.apple.com/us/app/moodbound/id6752506815`) and note that the app is free.
- Link to the new marketing site at [moodbound.app](https://moodbound.app) and its source repo [Evoke4350/moodbound.app](https://github.com/Evoke4350/moodbound.app).
- Align the closing license blurb with the free-on-App-Store wording.

## Test plan
- [x] Preview the rendered README on the PR page and confirm the links resolve.
- [x] Confirm no other content changed.