### PR TITLE
Data-quality + UX pass — sleep handling, empty states, math correctness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ __pycache__/
 .env
 .env.*
 *.p8
+
+# Nested marketing site repo (separate origin: Evoke4350/moodbound.app)
+moodbound.app/

--- a/moodbound/Resources/en.lproj/Localizable.strings
+++ b/moodbound/Resources/en.lproj/Localizable.strings
@@ -16,6 +16,8 @@
 "outlook.summary.bumpy" = "Some ups and downs lately. Sticking to your routine will help — watch for any sudden changes.";
 "outlook.summary.low_sleep_watch" = "Mostly steady, but a few short-sleep nights could tip things. Keep an eye on rest.";
 "outlook.summary.steady" = "You're in a good rhythm right now. Keep it up.";
+/* Shown when there are fewer than ~4 recent check-ins — the model can't say much yet, so we're explicit about that instead of overclaiming. */
+"outlook.summary.learning" = "Just a few entries so far. A few more check-ins and these insights will get sharper.";
 
 /* Data confidence tooltip shown under the concern-level / data-confidence / predictability row. */
 "insights.data_confidence.tooltip" = "More entries = sharper picture. Keep logging and your insights will get better.";

--- a/moodbound/Resources/es.lproj/Localizable.strings
+++ b/moodbound/Resources/es.lproj/Localizable.strings
@@ -14,6 +14,8 @@
 "outlook.summary.bumpy" = "Algunos altibajos últimamente. Mantener tu rutina ayudará — atenta/o a cambios bruscos.";
 "outlook.summary.low_sleep_watch" = "En general estable, pero algunas noches de poco sueño podrían desbalancear las cosas. Cuida tu descanso.";
 "outlook.summary.steady" = "Estás en un buen ritmo ahora mismo. Sigue así.";
+/* Mostrado cuando hay menos de ~4 registros recientes — el modelo aún no puede decir mucho, así que somos explícitos en lugar de exagerar. */
+"outlook.summary.learning" = "Solo unos pocos registros por ahora. Con algunos más, estos insights serán más nítidos.";
 
 /* Tooltip de confianza de datos. */
 "insights.data_confidence.tooltip" = "Más registros = imagen más nítida. Sigue registrando y tus insights mejorarán.";

--- a/moodbound/Services/BayesianSafetyEngine.swift
+++ b/moodbound/Services/BayesianSafetyEngine.swift
@@ -44,7 +44,14 @@ enum BayesianSafetyEngine {
 
         let recent = Array(sorted.suffix(14))
         let evidenceLevel = EvidenceLevel.from(observationCount: recent.count)
-        let lowSleepRate = fraction(recent.map { $0.sleepHours < 6.0 })
+        // sleepHours == 0 is the app's "unknown" sentinel (HealthKit miss /
+        // user skipped). Treat those days as uninformative rather than
+        // counting them as "<6h" — otherwise a run of skipped sleep entries
+        // inflates lowSleepRate and drives the LR upward with no real signal.
+        let lowSleepRate = fraction(recent.compactMap { v -> Bool? in
+            guard v.sleepHours > 0 else { return nil }
+            return v.sleepHours < 6.0
+        })
         let highVolatilityRate = fraction(recent.map { ($0.volatility7d ?? 0) >= 1.1 })
 
         // HealthKit-derived signals

--- a/moodbound/Services/BayesianSafetyEngine.swift
+++ b/moodbound/Services/BayesianSafetyEngine.swift
@@ -70,7 +70,13 @@ enum BayesianSafetyEngine {
         let prior = 0.22
         let priorOdds = prior / (1.0 - prior)
         var logLR = 0.0
-        logLR += 2.0 * forecast.value
+        // Use the unshrunk forecast here. RiskForecastService.value is already
+        // pulled toward 0.5 by sqrt(N/14); feeding it into the LR would
+        // compound that shrinkage with the posterior shrinkage below, which
+        // pushed N=4..10 results unrealistically close to the prior even when
+        // the underlying signal was strong. The forecast model exposes
+        // rawValue precisely so this layer can run its own attenuation.
+        logLR += 2.0 * forecast.rawValue
         logLR += 1.6 * elevatedPosterior
         logLR += 1.6 * depressivePosterior
         logLR += 1.2 * lowSleepRate
@@ -90,11 +96,14 @@ enum BayesianSafetyEngine {
         // Shrinkage: pull the posterior toward the prior (0.22) when the
         // window is sparse. With N=2, the LR can spike high off a single
         // distressing day; without this, severity could escalate to .high
-        // or .critical from two data points. The weight grows linearly to
-        // 1.0 by N=14, so an established record sees no attenuation.
-        // Severity bands and threshold values are unchanged — only the
-        // posterior they read from is now sample-size aware.
-        let shrinkWeight = min(1.0, Double(recent.count) / 14.0)
+        // or .critical from two data points. We use sqrt(N/14) — the same
+        // family used by RiskForecastService and by the CI uncertainty
+        // term — so confidence builds faster than linear in the 4..10
+        // regime that users actually see most often, while still pinning
+        // the posterior near the prior at N=1..2. Severity bands and
+        // threshold values are unchanged — only the posterior they read
+        // from is now sample-size aware.
+        let shrinkWeight = min(1.0, sqrt(Double(recent.count) / 14.0))
         let posteriorRisk = (shrinkWeight * rawPosteriorRisk) + ((1.0 - shrinkWeight) * prior)
 
         let severity: SafetySeverity

--- a/moodbound/Services/BayesianSafetyEngine.swift
+++ b/moodbound/Services/BayesianSafetyEngine.swift
@@ -13,6 +13,8 @@ struct BayesianSafetyResult: Equatable {
     let evidence: ModelEvidence
     let recommendedActions: [String]
     let messages: [String]
+    let evidenceLevel: EvidenceLevel
+    let observationsLast14d: Int
 }
 
 enum BayesianSafetyEngine {
@@ -34,11 +36,14 @@ enum BayesianSafetyEngine {
                 confidence: 0,
                 evidence: ModelEvidence(windowStart: Date(), windowEnd: Date(), signals: []),
                 recommendedActions: [],
-                messages: []
+                messages: [],
+                evidenceLevel: .insufficient,
+                observationsLast14d: 0
             )
         }
 
         let recent = Array(sorted.suffix(14))
+        let evidenceLevel = EvidenceLevel.from(observationCount: recent.count)
         let lowSleepRate = fraction(recent.map { $0.sleepHours < 6.0 })
         let highVolatilityRate = fraction(recent.map { ($0.volatility7d ?? 0) >= 1.1 })
 
@@ -80,7 +85,17 @@ enum BayesianSafetyEngine {
         let likelihoodRatio = exp(logLR)
 
         let posteriorOdds = priorOdds * likelihoodRatio
-        let posteriorRisk = posteriorOdds / (1.0 + posteriorOdds)
+        let rawPosteriorRisk = posteriorOdds / (1.0 + posteriorOdds)
+
+        // Shrinkage: pull the posterior toward the prior (0.22) when the
+        // window is sparse. With N=2, the LR can spike high off a single
+        // distressing day; without this, severity could escalate to .high
+        // or .critical from two data points. The weight grows linearly to
+        // 1.0 by N=14, so an established record sees no attenuation.
+        // Severity bands and threshold values are unchanged — only the
+        // posterior they read from is now sample-size aware.
+        let shrinkWeight = min(1.0, Double(recent.count) / 14.0)
+        let posteriorRisk = (shrinkWeight * rawPosteriorRisk) + ((1.0 - shrinkWeight) * prior)
 
         let severity: SafetySeverity
         switch posteriorRisk {
@@ -94,36 +109,47 @@ enum BayesianSafetyEngine {
             severity = .none
         }
 
+        // With < 4 recent observations, every "trend" / "shift" signal is
+        // dominated by single-day variance. Emitting "There's been a
+        // noticeable shift" off two data points reads as the app overreacting.
+        // Replace the narrative bullets with a single hedged sentence so the
+        // user knows we're listening but not pretending to be confident.
+        // The numeric severity above is left untouched: if the data really
+        // does indicate distress, the safety actions still surface.
         var signals: [String] = []
-        if forecast.value >= 0.6 {
-            signals.append("Your week ahead looks bumpier than usual.")
-        }
-        if elevatedPosterior >= 0.45 {
-            signals.append("Your recent pattern is leaning toward the high end.")
-        }
-        if depressivePosterior >= 0.45 {
-            signals.append("Your recent pattern is leaning toward the low end.")
-        }
-        if lowSleepRate >= 0.3 {
-            signals.append("You've had several short sleep nights recently.")
-        }
-        if highVolatilityRate >= 0.35 {
-            signals.append("Your mood has been swinging more than usual.")
-        }
-        if !changePoints.isEmpty {
-            signals.append("There's been a noticeable shift in your pattern recently.")
-        }
-        if bayesianChangeProbability >= 0.25 {
-            signals.append("Things seem to be shifting — worth paying attention to.")
-        }
-        if wassersteinDriftScore >= 0.22 {
-            signals.append("Your recent days look different from your usual pattern.")
-        }
-        if lowHRVRate >= 0.3 {
-            signals.append("Your heart rate variability has been low — your body may be under stress.")
-        }
-        if lowActivityRate >= 0.4 {
-            signals.append("Your activity has been unusually low recently.")
+        if evidenceLevel == .insufficient {
+            signals.append("We're still learning your patterns — a few more check-ins will sharpen these insights.")
+        } else {
+            if forecast.value >= 0.6 {
+                signals.append("Your week ahead looks bumpier than usual.")
+            }
+            if elevatedPosterior >= 0.45 {
+                signals.append("Your recent pattern is leaning toward the high end.")
+            }
+            if depressivePosterior >= 0.45 {
+                signals.append("Your recent pattern is leaning toward the low end.")
+            }
+            if lowSleepRate >= 0.3 {
+                signals.append("You've had several short sleep nights recently.")
+            }
+            if highVolatilityRate >= 0.35 {
+                signals.append("Your mood has been swinging more than usual.")
+            }
+            if !changePoints.isEmpty {
+                signals.append("There's been a noticeable shift in your pattern recently.")
+            }
+            if bayesianChangeProbability >= 0.25 {
+                signals.append("Things seem to be shifting — worth paying attention to.")
+            }
+            if wassersteinDriftScore >= 0.22 {
+                signals.append("Your recent days look different from your usual pattern.")
+            }
+            if lowHRVRate >= 0.3 {
+                signals.append("Your heart rate variability has been low — your body may be under stress.")
+            }
+            if lowActivityRate >= 0.4 {
+                signals.append("Your activity has been unusually low recently.")
+            }
         }
 
         let recommendedActions: [String]
@@ -150,7 +176,9 @@ enum BayesianSafetyEngine {
                 signals: signals
             ),
             recommendedActions: recommendedActions,
-            messages: SafetyCopyPolicy.sanitize(signals)
+            messages: SafetyCopyPolicy.sanitize(signals),
+            evidenceLevel: evidenceLevel,
+            observationsLast14d: recent.count
         )
     }
 

--- a/moodbound/Services/BayesianSafetyEngine.swift
+++ b/moodbound/Services/BayesianSafetyEngine.swift
@@ -129,7 +129,11 @@ enum BayesianSafetyEngine {
         if evidenceLevel == .insufficient {
             signals.append("We're still learning your patterns — a few more check-ins will sharpen these insights.")
         } else {
-            if forecast.value >= 0.6 {
+            // Use rawValue so this bullet fires off the same forecast magnitude
+            // the LR above used. If we read forecast.value (shrunk), severity
+            // could escalate at N=4..10 from a strong signal while this copy
+            // stayed silent — the user would see the badge with no explanation.
+            if forecast.rawValue >= 0.6 {
                 signals.append("Your week ahead looks bumpier than usual.")
             }
             if elevatedPosterior >= 0.45 {

--- a/moodbound/Services/ConformalCalibrationService.swift
+++ b/moodbound/Services/ConformalCalibrationService.swift
@@ -33,14 +33,18 @@ enum ConformalCalibrationService {
 
     private static func proxyRisk(_ vector: TemporalFeatureVector) -> Double {
         let mood = abs(vector.moodLevel) / 3.0
-        let sleep = max(0, (6.0 - vector.sleepHours) / 3.0)
+        // sleepHours == 0 is the app's "unknown" sentinel; treat as neutral
+        // instead of "6h deficit" so skipped sleep entries don't inflate risk.
+        let sleep = vector.sleepHours > 0 ? max(0, (6.0 - vector.sleepHours) / 3.0) : 0
         let volatility = min(1, (vector.volatility7d ?? 0.5) / 1.5)
         return clamp((0.45 * mood) + (0.35 * sleep) + (0.2 * volatility))
     }
 
     private static func proxyOutcome(_ vector: TemporalFeatureVector) -> Double {
         let manicOrDepressive = abs(vector.moodLevel) >= 2.0
-        let severeSleep = vector.sleepHours <= 5.0 || vector.sleepHours >= 10.5
+        // Same unknown convention: don't fire "severe sleep" just because the
+        // user skipped logging sleep that day.
+        let severeSleep = vector.sleepHours > 0 && (vector.sleepHours <= 5.0 || vector.sleepHours >= 10.5)
         let elevatedAnxiety = vector.anxiety >= 2.5
         return (manicOrDepressive || severeSleep || elevatedAnxiety) ? 1.0 : 0.0
     }

--- a/moodbound/Services/ConformalCalibrationService.swift
+++ b/moodbound/Services/ConformalCalibrationService.swift
@@ -16,7 +16,8 @@ enum ConformalCalibrationService {
             value: raw.value,
             ciLow: min(low, high),
             ciHigh: max(low, high),
-            calibrationError: min(0.5, max(0, raw.calibrationError * 0.7))
+            calibrationError: min(0.5, max(0, raw.calibrationError * 0.7)),
+            rawValue: raw.rawValue
         )
     }
 

--- a/moodbound/Services/DirectionalSignalService.swift
+++ b/moodbound/Services/DirectionalSignalService.swift
@@ -16,28 +16,37 @@ enum DirectionalSignalService {
         let sorted = vectors.sorted { $0.timestamp < $1.timestamp }
         guard sorted.count >= 8 else { return [] }
 
-        let sleepDeficit = sorted.map { max(0, 7.0 - $0.sleepHours) }
-        let nextDayMood = sorted.map(\.moodLevel)
-        let triggerLoad = sorted.map { $0.triggerLoad7d ?? 0 }
-        let nextDayAnxiety = sorted.map(\.anxiety)
-        let medAdherence = sorted.map { $0.medAdherenceRate7d ?? 0.5 }
-        let nextDayVolatility = sorted.map { $0.volatility7d ?? 0.5 }
+        // Per-series optional sources. A nil at index i means "no signal that
+        // day"; we drop pairs where either side is nil rather than imputing a
+        // sentinel like 0.5, which would otherwise pull every correlation
+        // toward zero and falsely flag uninformative days as "neutral evidence".
+        // sleepHours == 0 is the app's "unknown" convention, so it is also nil here.
+        let sleepDeficit: [Double?] = sorted.map { $0.sleepHours > 0 ? max(0, 7.0 - $0.sleepHours) : nil }
+        let nextDayMood: [Double?] = sorted.map { Double($0.moodLevel) }
+        let triggerLoad: [Double?] = sorted.map { $0.triggerLoad7d }
+        let nextDayAnxiety: [Double?] = sorted.map { Double($0.anxiety) }
+        let medAdherence: [Double?] = sorted.map { $0.medAdherenceRate7d }
+        let nextDayVolatility: [Double?] = sorted.map { $0.volatility7d }
 
-        let candidates: [(String, String, Double)] = [
-            ("Sleep Deficit", "Next-Day Mood Elevation", laggedCorrelation(source: sleepDeficit, target: nextDayMood, lag: lagDays)),
-            ("Trigger Load", "Next-Day Anxiety", laggedCorrelation(source: triggerLoad, target: nextDayAnxiety, lag: lagDays)),
-            ("Medication Adherence", "Next-Day Volatility (inverse)", -laggedCorrelation(source: medAdherence, target: nextDayVolatility, lag: lagDays)),
+        let sleepProbe = laggedCorrelation(source: sleepDeficit, target: nextDayMood, lag: lagDays)
+        let triggerProbe = laggedCorrelation(source: triggerLoad, target: nextDayAnxiety, lag: lagDays)
+        let medProbe = laggedCorrelation(source: medAdherence, target: nextDayVolatility, lag: lagDays)
+
+        let candidates: [(String, String, LaggedCorrelation)] = [
+            ("Sleep Deficit", "Next-Day Mood Elevation", sleepProbe),
+            ("Trigger Load", "Next-Day Anxiety", triggerProbe),
+            ("Medication Adherence", "Next-Day Volatility (inverse)", medProbe.negated),
         ]
 
         return candidates
-            .filter { abs($0.2) >= 0.25 }
-            .map { source, target, corr in
-                let confidence = min(0.95, abs(corr) * sqrt(Double(sorted.count) / 20.0))
+            .filter { $0.2.pairs >= 6 && abs($0.2.r) >= 0.25 }
+            .map { source, target, result in
+                let confidence = min(0.95, abs(result.r) * sqrt(Double(result.pairs) / 20.0))
                 return DirectionalSignalProbe(
                     source: source,
                     target: target,
                     lagDays: lagDays,
-                    strength: corr,
+                    strength: result.r,
                     confidence: confidence,
                     caveat: standardCaveat
                 )
@@ -45,18 +54,27 @@ enum DirectionalSignalService {
             .sorted { abs($0.strength) > abs($1.strength) }
     }
 
-    private static func laggedCorrelation(source: [Double], target: [Double], lag: Int) -> Double {
-        guard lag > 0 else { return 0 }
-        guard source.count == target.count, source.count > lag else { return 0 }
+    private struct LaggedCorrelation {
+        let r: Double
+        let pairs: Int
+
+        var negated: LaggedCorrelation { LaggedCorrelation(r: -r, pairs: pairs) }
+        static let zero = LaggedCorrelation(r: 0, pairs: 0)
+    }
+
+    private static func laggedCorrelation(source: [Double?], target: [Double?], lag: Int) -> LaggedCorrelation {
+        guard lag > 0 else { return .zero }
+        guard source.count == target.count, source.count > lag else { return .zero }
 
         var x: [Double] = []
         var y: [Double] = []
         for index in 0..<(source.count - lag) {
-            x.append(source[index])
-            y.append(target[index + lag])
+            guard let sx = source[index], let ty = target[index + lag] else { continue }
+            x.append(sx)
+            y.append(ty)
         }
 
-        return pearsonCorrelation(x: x, y: y)
+        return LaggedCorrelation(r: pearsonCorrelation(x: x, y: y), pairs: x.count)
     }
 
     private static func pearsonCorrelation(x: [Double], y: [Double]) -> Double {

--- a/moodbound/Services/DirectionalSignalService.swift
+++ b/moodbound/Services/DirectionalSignalService.swift
@@ -38,8 +38,16 @@ enum DirectionalSignalService {
             ("Medication Adherence", "Next-Day Volatility (inverse)", medProbe.negated),
         ]
 
+        // We need *enough* pairs after nil-drop to compute a stable correlation.
+        // Pearson is meaningless with <3 pairs; below ~half the available
+        // observations we can't trust the signal. Scale the floor relative to
+        // the maximum possible (sorted.count - lagDays), with a hard minimum of
+        // 4 so very short series can still produce a low-confidence hint.
+        let maxPossiblePairs = sorted.count - lagDays
+        let minPairs = max(4, (maxPossiblePairs * 2) / 3)
+
         return candidates
-            .filter { $0.2.pairs >= 6 && abs($0.2.r) >= 0.25 }
+            .filter { $0.2.pairs >= minPairs && abs($0.2.r) >= 0.25 }
             .map { source, target, result in
                 let confidence = min(0.95, abs(result.r) * sqrt(Double(result.pairs) / 20.0))
                 return DirectionalSignalProbe(

--- a/moodbound/Services/EvidenceLevel.swift
+++ b/moodbound/Services/EvidenceLevel.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+// Coarse classification of how much recent evidence the model is working
+// from. Used to gate confident-sounding user-facing copy: with fewer than a
+// handful of recent check-ins, the underlying point estimates are too noisy
+// to phrase as decisive trends ("Pretty turbulent right now"), even though
+// the math itself remains valid. Decisions about clinical safety severity
+// are NOT gated by this — those must remain honest regardless of N — but
+// the surrounding narrative copy is hedged.
+enum EvidenceLevel: String, Equatable {
+    case insufficient
+    case learning
+    case established
+
+    // Anchored to the 14-day window most insights operate over. Below 4
+    // observations the picture is dominated by a single day's variance;
+    // 4–9 is enough to spot directionality but not to make confident
+    // claims; 10+ approaches a usable signal.
+    static func from(observationCount: Int) -> EvidenceLevel {
+        if observationCount < 4 { return .insufficient }
+        if observationCount < 10 { return .learning }
+        return .established
+    }
+
+    var allowsConfidentNarrative: Bool {
+        self == .established
+    }
+}

--- a/moodbound/Services/InsightEngine.swift
+++ b/moodbound/Services/InsightEngine.swift
@@ -50,6 +50,11 @@ struct InsightSnapshot {
     var weatherCoverageDays: Int
     var rainyMoodDelta: Double?
     var hotMoodDelta: Double?
+    // Sufficiency gate for user-facing narrative copy. Insufficient evidence
+    // means views should fall back to hedged "still learning" phrasing rather
+    // than confident trend labels.
+    var evidenceLevel: EvidenceLevel
+    var observationsLast14d: Int
 }
 
 enum InsightEngine {
@@ -120,7 +125,9 @@ enum InsightEngine {
             weatherCity: weather.city,
             weatherCoverageDays: weather.coverageDays,
             rainyMoodDelta: weather.rainyMoodDelta,
-            hotMoodDelta: weather.hotMoodDelta
+            hotMoodDelta: weather.hotMoodDelta,
+            evidenceLevel: bayesian.evidenceLevel,
+            observationsLast14d: bayesian.observationsLast14d
         )
     }
 

--- a/moodbound/Services/InsightEngine.swift
+++ b/moodbound/Services/InsightEngine.swift
@@ -148,7 +148,14 @@ enum InsightEngine {
             .filter { !$0.isEmpty }
         guard !names.isEmpty else { return nil }
         let counts = Dictionary(grouping: names, by: { $0 }).mapValues(\.count)
-        return counts.max(by: { $0.value < $1.value })?.key
+        // Sort by count desc, then name asc, so ties resolve to a deterministic
+        // alphabetical winner instead of dictionary iteration order.
+        return counts
+            .sorted { lhs, rhs in
+                if lhs.value != rhs.value { return lhs.value > rhs.value }
+                return lhs.key < rhs.key
+            }
+            .first?.key
     }
 
     private static func safetyAssessment(from bayesian: BayesianSafetyResult) -> SafetyAssessment {

--- a/moodbound/Services/MedicationTrajectoryService.swift
+++ b/moodbound/Services/MedicationTrajectoryService.swift
@@ -45,7 +45,7 @@ enum MedicationTrajectoryService {
         }
 
         let names = Set(groupedTakenShort.keys).union(groupedMissedShort.keys)
-        return names.compactMap { name in
+        return names.compactMap { name -> MedicationTrajectory? in
             let takenShort = groupedTakenShort[name] ?? []
             let missedShort = groupedMissedShort[name] ?? []
             let takenMedium = groupedTakenMedium[name] ?? []
@@ -53,8 +53,16 @@ enum MedicationTrajectoryService {
 
             let support = min(takenShort.count, missedShort.count)
             let sufficient = support >= minimumSamples
-            let shortDelta = average(takenShort) - average(missedShort)
-            let mediumDelta = average(takenMedium) - average(missedMedium)
+            // Both arms must have at least one observation before we can
+            // produce a delta; otherwise average([])==0 would silently masquerade
+            // as a real risk score and the difference would be meaningless.
+            guard let takenShortAvg = mean(takenShort),
+                  let missedShortAvg = mean(missedShort) else { return nil }
+            let shortDelta = takenShortAvg - missedShortAvg
+            let mediumDelta: Double = {
+                guard let t = mean(takenMedium), let m = mean(missedMedium) else { return shortDelta }
+                return t - m
+            }()
             let spread = standardDeviation(takenShort + missedShort + takenMedium + missedMedium)
             let uncertainty = max(0.05, min(1.0, spread / sqrt(Double(max(1, support)))))
 
@@ -93,24 +101,24 @@ enum MedicationTrajectoryService {
         sorted: [MoodEntry],
         riskByEntryId: [ObjectIdentifier: Double]
     ) -> Double? {
-        guard index + 1 < sorted.count else { return nil }
+        let start = index + 1
+        guard start < sorted.count, count > 0 else { return nil }
         let upperBound = min(sorted.count - 1, index + count)
-        let future = sorted[(index + 1)...upperBound]
+        guard upperBound >= start else { return nil }
+        let future = sorted[start...upperBound]
         let values = future.compactMap { riskByEntryId[ObjectIdentifier($0)] }
-        guard !values.isEmpty else { return nil }
-        return average(values)
+        return mean(values)
     }
 
-    private static func average(_ values: [Double]) -> Double {
-        guard !values.isEmpty else { return 0 }
+    private static func mean(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
         return values.reduce(0, +) / Double(values.count)
     }
 
     private static func standardDeviation(_ values: [Double]) -> Double {
-        guard values.count > 1 else { return 0 }
-        let mean = average(values)
+        guard values.count > 1, let m = mean(values) else { return 0 }
         let variance = values.reduce(0) { partial, value in
-            let delta = value - mean
+            let delta = value - m
             return partial + (delta * delta)
         } / Double(values.count - 1)
         return sqrt(variance)

--- a/moodbound/Services/MedicationTrajectoryService.swift
+++ b/moodbound/Services/MedicationTrajectoryService.swift
@@ -53,16 +53,17 @@ enum MedicationTrajectoryService {
 
             let support = min(takenShort.count, missedShort.count)
             let sufficient = support >= minimumSamples
-            // Both arms must have at least one observation before we can
-            // produce a delta; otherwise average([])==0 would silently masquerade
-            // as a real risk score and the difference would be meaningless.
+            // Both arms must have at least one observation before we can produce
+            // a delta; otherwise average([])==0 would silently masquerade as a
+            // real risk score and the difference would be meaningless. The
+            // producer loop above appends to short and medium together, so the
+            // medium arrays' counts mirror the short arrays' counts.
             guard let takenShortAvg = mean(takenShort),
-                  let missedShortAvg = mean(missedShort) else { return nil }
+                  let missedShortAvg = mean(missedShort),
+                  let takenMediumAvg = mean(takenMedium),
+                  let missedMediumAvg = mean(missedMedium) else { return nil }
             let shortDelta = takenShortAvg - missedShortAvg
-            let mediumDelta: Double = {
-                guard let t = mean(takenMedium), let m = mean(missedMedium) else { return shortDelta }
-                return t - m
-            }()
+            let mediumDelta = takenMediumAvg - missedMediumAvg
             let spread = standardDeviation(takenShort + missedShort + takenMedium + missedMedium)
             let uncertainty = max(0.05, min(1.0, spread / sqrt(Double(max(1, support)))))
 

--- a/moodbound/Services/ModelHealthService.swift
+++ b/moodbound/Services/ModelHealthService.swift
@@ -28,7 +28,14 @@ enum ModelHealthService {
         }
 
         let drift = driftScore(vectors: sorted)
-        let staleDays = max(0, Calendar.current.dateComponents([.day], from: latest.timestamp, to: now).day ?? 0)
+        // Compare calendar day boundaries, not raw 24-hour deltas. With the
+        // raw delta, an entry logged yesterday at 8pm against a "now" of 6am
+        // today reads as 0 days stale even though the user clearly missed a
+        // day; with calendar boundaries it correctly reads as 1.
+        let calendar = Calendar.current
+        let latestDay = calendar.startOfDay(for: latest.timestamp)
+        let nowDay = calendar.startOfDay(for: now)
+        let staleDays = max(0, calendar.dateComponents([.day], from: latestDay, to: nowDay).day ?? 0)
         var alerts: [String] = []
 
         if drift >= 0.45 {

--- a/moodbound/Services/RiskForecastService.swift
+++ b/moodbound/Services/RiskForecastService.swift
@@ -38,8 +38,17 @@ enum RiskForecastService {
             (0.7 * changeRate) -
             1.65
 
-        let value = sigmoid(linearScore)
+        // Pull the raw sigmoid output toward the neutral prior (0.5) when
+        // the recent window is sparse. The shrinkage weight grows linearly
+        // from 0 → 1 as recent.count approaches 14; below that, a single
+        // high-anxiety day can no longer drag the headline forecast above
+        // 0.5 by itself. The CI computed below already widens with sqrt(N),
+        // so we don't need to widen it further — only the point estimate
+        // was misbehaving as a confidence overstatement.
+        let rawValue = sigmoid(linearScore)
         let sampleSize = Double(recent.count)
+        let shrinkWeight = min(1.0, sampleSize / 14.0)
+        let value = (shrinkWeight * rawValue) + ((1.0 - shrinkWeight) * 0.5)
         let uncertaintyScale = max(0.08, 0.35 / sqrt(max(1.0, sampleSize)))
         let low = clamp(value - uncertaintyScale)
         let high = clamp(value + uncertaintyScale)

--- a/moodbound/Services/RiskForecastService.swift
+++ b/moodbound/Services/RiskForecastService.swift
@@ -5,9 +5,23 @@ struct ProbabilisticScore: Equatable {
     let ciLow: Double
     let ciHigh: Double
     let calibrationError: Double
+    // Pre-shrinkage forecast value. Downstream consumers (BayesianSafetyEngine)
+    // need the unattenuated signal to drive their own posterior — feeding the
+    // already-shrunk `value` would compound shrinkage and silently suppress
+    // genuine distress signals at intermediate sample sizes (N=4..10). UI
+    // surfaces should use `value` (shrunk); model math should use `rawValue`.
+    let rawValue: Double
 
     var ciWidth: Double {
         ciHigh - ciLow
+    }
+
+    init(value: Double, ciLow: Double, ciHigh: Double, calibrationError: Double, rawValue: Double? = nil) {
+        self.value = value
+        self.ciLow = ciLow
+        self.ciHigh = ciHigh
+        self.calibrationError = calibrationError
+        self.rawValue = rawValue ?? value
     }
 }
 
@@ -39,15 +53,16 @@ enum RiskForecastService {
             1.65
 
         // Pull the raw sigmoid output toward the neutral prior (0.5) when
-        // the recent window is sparse. The shrinkage weight grows linearly
-        // from 0 → 1 as recent.count approaches 14; below that, a single
-        // high-anxiety day can no longer drag the headline forecast above
-        // 0.5 by itself. The CI computed below already widens with sqrt(N),
-        // so we don't need to widen it further — only the point estimate
-        // was misbehaving as a confidence overstatement.
+        // the recent window is sparse. We use sqrt(N/14) — the same scaling
+        // family as the CI uncertainty term below — so confidence builds
+        // faster than linear in the 4–10 regime that the user actually sees
+        // most often, while still pinning the headline near 0.5 at N=1..2.
+        // The raw value is preserved on the result so downstream consumers
+        // (BayesianSafetyEngine) can compute their own posterior without
+        // double-shrinking through this attenuated value.
         let rawValue = sigmoid(linearScore)
         let sampleSize = Double(recent.count)
-        let shrinkWeight = min(1.0, sampleSize / 14.0)
+        let shrinkWeight = min(1.0, sqrt(sampleSize / 14.0))
         let value = (shrinkWeight * rawValue) + ((1.0 - shrinkWeight) * 0.5)
         let uncertaintyScale = max(0.08, 0.35 / sqrt(max(1.0, sampleSize)))
         let low = clamp(value - uncertaintyScale)
@@ -60,7 +75,8 @@ enum RiskForecastService {
             value: value,
             ciLow: min(low, high),
             ciHigh: max(low, high),
-            calibrationError: calibrationError
+            calibrationError: calibrationError,
+            rawValue: rawValue
         )
     }
 

--- a/moodbound/Services/RiskForecastService.swift
+++ b/moodbound/Services/RiskForecastService.swift
@@ -28,18 +28,14 @@ enum RiskForecastService {
         let depressivePosterior = average(latent.posteriors.suffix(14).map { $0.distribution.depressive })
         let lowSleepRate = fraction(recent.map { $0.sleepHours < 6.0 })
         let highVolatilityRate = fraction(recent.map { ($0.volatility7d ?? 0) >= 1.1 })
-        // Bug fix: previously `recent.count / 3` was integer division, so
-        // counts of 1 and 2 collapsed to 0 (then clamped to 1.0 by max), and
-        // counts of 4 and 5 both became 1 — flattening the rate scale at the
-        // low end. Use Double division so the denominator scales smoothly.
-        let recentChangeRate = min(1.0, Double(changePoints.count) / max(1.0, Double(recent.count) / 3.0))
+        let changeRate = recentChangeRate(changeCount: changePoints.count, recentCount: recent.count)
 
         let linearScore =
             (1.2 * elevatedPosterior) +
             (1.2 * depressivePosterior) +
             (0.9 * lowSleepRate) +
             (0.8 * highVolatilityRate) +
-            (0.7 * recentChangeRate) -
+            (0.7 * changeRate) -
             1.65
 
         let value = sigmoid(linearScore)
@@ -57,6 +53,16 @@ enum RiskForecastService {
             ciHigh: max(low, high),
             calibrationError: calibrationError
         )
+    }
+
+    // Internal so tests can pin the small-N behavior. Previously this was
+    // `recent.count / 3` (integer division), which made N=1,2 collapse to 0
+    // and N=4,5 collapse to 1 — flattening the rate scale at the low end so
+    // a single change point would saturate to 1.0 across N=1..5. Double
+    // division keeps the denominator continuous; max(1.0, …) prevents
+    // amplification when N<3 would otherwise inflate the rate above 1.
+    static func recentChangeRate(changeCount: Int, recentCount: Int) -> Double {
+        min(1.0, Double(changeCount) / max(1.0, Double(recentCount) / 3.0))
     }
 
     private static func sigmoid(_ x: Double) -> Double {

--- a/moodbound/Services/RiskForecastService.swift
+++ b/moodbound/Services/RiskForecastService.swift
@@ -45,7 +45,12 @@ enum RiskForecastService {
 
         let elevatedPosterior = average(latent.posteriors.suffix(14).map { $0.distribution.elevated })
         let depressivePosterior = average(latent.posteriors.suffix(14).map { $0.distribution.depressive })
-        let lowSleepRate = fraction(recent.map { $0.sleepHours < 6.0 })
+        // sleepHours == 0 is the app's "unknown" sentinel; drop those days
+        // from the rate so skipped entries don't inflate "low sleep" signal.
+        let lowSleepRate = fraction(recent.compactMap { v -> Bool? in
+            guard v.sleepHours > 0 else { return nil }
+            return v.sleepHours < 6.0
+        })
         let highVolatilityRate = fraction(recent.map { ($0.volatility7d ?? 0) >= 1.1 })
         let changeRate = recentChangeRate(changeCount: changePoints.count, recentCount: recent.count)
 

--- a/moodbound/Services/RiskForecastService.swift
+++ b/moodbound/Services/RiskForecastService.swift
@@ -16,6 +16,11 @@ struct ProbabilisticScore: Equatable {
         ciHigh - ciLow
     }
 
+    // `rawValue` defaults to `value` for ergonomic test fixture construction,
+    // but any production path that constructs a ProbabilisticScore from a
+    // shrunk number MUST pass the unshrunk value explicitly. Without that,
+    // BayesianSafetyEngine will silently re-introduce the double-shrinkage
+    // bug — its LR reads `rawValue` precisely to avoid that compound.
     init(value: Double, ciLow: Double, ciHigh: Double, calibrationError: Double, rawValue: Double? = nil) {
         self.value = value
         self.ciLow = ciLow

--- a/moodbound/Services/RiskForecastService.swift
+++ b/moodbound/Services/RiskForecastService.swift
@@ -28,7 +28,11 @@ enum RiskForecastService {
         let depressivePosterior = average(latent.posteriors.suffix(14).map { $0.distribution.depressive })
         let lowSleepRate = fraction(recent.map { $0.sleepHours < 6.0 })
         let highVolatilityRate = fraction(recent.map { ($0.volatility7d ?? 0) >= 1.1 })
-        let recentChangeRate = min(1.0, Double(changePoints.count) / max(1.0, Double(recent.count / 3)))
+        // Bug fix: previously `recent.count / 3` was integer division, so
+        // counts of 1 and 2 collapsed to 0 (then clamped to 1.0 by max), and
+        // counts of 4 and 5 both became 1 — flattening the rate scale at the
+        // low end. Use Double division so the denominator scales smoothly.
+        let recentChangeRate = min(1.0, Double(changePoints.count) / max(1.0, Double(recent.count) / 3.0))
 
         let linearScore =
             (1.2 * elevatedPosterior) +

--- a/moodbound/ViewModels/MoodViewModel.swift
+++ b/moodbound/ViewModels/MoodViewModel.swift
@@ -38,7 +38,12 @@ class MoodViewModel {
     }
 
     func entriesWithinDays(entries: [MoodEntry], days: Int, now: Date = AppClock.now) -> [MoodEntry] {
-        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: now) ?? now
+        // Anchor to start-of-day so a "last 7 days" filter at 9am still
+        // includes entries from the morning of day -7. Subtracting raw 24-hour
+        // intervals from the wall-clock `now` would silently drop those.
+        let calendar = Calendar.current
+        let startToday = calendar.startOfDay(for: now)
+        let cutoff = calendar.date(byAdding: .day, value: -(days - 1), to: startToday) ?? startToday
         return entries.filter { $0.timestamp >= cutoff }
     }
 }

--- a/moodbound/Views/HistoryView.swift
+++ b/moodbound/Views/HistoryView.swift
@@ -434,7 +434,13 @@ struct HistoryView: View {
             .frame(height: horizontalSizeClass == .regular ? 270 : 250)
 
             if let selectedEntry = selectedSleepEntry {
-                Text("\(String(format: "%.1f", selectedEntry.sleepHours))h sleep on \(selectedEntry.timestamp.formatted(date: .abbreviated, time: .omitted))")
+                // sleepHours == 0 is the "unknown" sentinel; the chart hides
+                // those bars, so the popover should say "unlogged" instead of
+                // printing a phantom 0.0h value.
+                let label: String = selectedEntry.sleepHours > 0
+                    ? "\(String(format: "%.1f", selectedEntry.sleepHours))h sleep on \(selectedEntry.timestamp.formatted(date: .abbreviated, time: .omitted))"
+                    : "Sleep not logged on \(selectedEntry.timestamp.formatted(date: .abbreviated, time: .omitted))"
+                Text(label)
                     .font(.footnote.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .transition(.opacity)

--- a/moodbound/Views/HistoryView.swift
+++ b/moodbound/Views/HistoryView.swift
@@ -23,7 +23,10 @@ struct HistoryView: View {
     private struct DailyAggregate: Identifiable {
         let date: Date
         let mood: Double
-        let sleep: Double
+        // sleep is optional because sleepHours == 0 is the "unknown" sentinel,
+        // and a day with no known sleep observation should not contribute to
+        // averages or render a zero-height bar in the chart.
+        let sleep: Double?
         var id: Date { date }
     }
 
@@ -168,7 +171,8 @@ struct HistoryView: View {
     private var windowSummaryCard: some View {
         let avgMood = aggregatedEntries.map(\.mood).average
         let moodVolatility = aggregatedEntries.map(\.mood).populationStdDev
-        let avgSleep = aggregatedEntries.map(\.sleep).average
+        let knownSleep = aggregatedEntries.compactMap(\.sleep)
+        let avgSleep: Double? = knownSleep.isEmpty ? nil : knownSleep.average
 
         return HStack {
             summaryMetric(
@@ -185,7 +189,7 @@ struct HistoryView: View {
             Spacer()
             summaryMetric(
                 title: "Avg Sleep",
-                value: String(format: "%.1fh", avgSleep),
+                value: avgSleep.map { String(format: "%.1fh", $0) } ?? "—",
                 tint: .indigo
             )
         }
@@ -214,7 +218,11 @@ struct HistoryView: View {
         case .quarter:
             days = 90
         }
-        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: appNow)!
+        // Anchor to startOfDay so entries from the morning of the boundary
+        // day are included regardless of the current wall-clock time.
+        let calendar = Calendar.current
+        let startToday = calendar.startOfDay(for: appNow)
+        let cutoff = calendar.date(byAdding: .day, value: -(days - 1), to: startToday) ?? startToday
         return entries.filter { $0.timestamp >= cutoff }
     }
 
@@ -225,7 +233,11 @@ struct HistoryView: View {
 
         return grouped.map { date, bucket in
             let moodAverage = bucket.reduce(0.0) { $0 + Double($1.moodLevel) } / Double(bucket.count)
-            let sleepAverage = bucket.reduce(0.0) { $0 + $1.sleepHours } / Double(bucket.count)
+            // sleepHours == 0 means "unknown" — a user logged everything except
+            // their sleep that day. Average only over known values; if every
+            // entry that day was unknown, the day has no sleep aggregate.
+            let knownSleep = bucket.map(\.sleepHours).filter { $0 > 0 }
+            let sleepAverage: Double? = knownSleep.isEmpty ? nil : knownSleep.reduce(0, +) / Double(knownSleep.count)
             return DailyAggregate(date: date, mood: moodAverage, sleep: sleepAverage)
         }
         .sorted { $0.date < $1.date }
@@ -370,17 +382,21 @@ struct HistoryView: View {
             Text("Sleep Pattern")
                 .font(.system(size: 22, weight: .bold, design: .rounded))
 
-            Chart(aggregatedEntries) { point in
-                BarMark(
-                    x: .value("Date", point.date, unit: .day),
-                    y: .value("Hours", point.sleep)
-                )
-                .foregroundStyle(
-                    point.sleep < 6 || point.sleep > 10
-                    ? MoodboundDesign.accent.opacity(0.68)
-                    : MoodboundDesign.tint.opacity(0.72)
-                )
-                .cornerRadius(4)
+            Chart {
+                ForEach(aggregatedEntries) { point in
+                    if let sleep = point.sleep {
+                        BarMark(
+                            x: .value("Date", point.date, unit: .day),
+                            y: .value("Hours", sleep)
+                        )
+                        .foregroundStyle(
+                            sleep < 6 || sleep > 10
+                            ? MoodboundDesign.accent.opacity(0.68)
+                            : MoodboundDesign.tint.opacity(0.72)
+                        )
+                        .cornerRadius(4)
+                    }
+                }
 
                 RuleMark(y: .value("Target", 8))
                     .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))

--- a/moodbound/Views/HomeView.swift
+++ b/moodbound/Views/HomeView.swift
@@ -124,7 +124,7 @@ struct HomeView: View {
 
     private func todayOutlookCard(snapshot: InsightSnapshot) -> some View {
         let score = outlookScore(snapshot: snapshot)
-        let band = outlookBand(score: score)
+        let band = outlookBand(score: score, evidenceLevel: snapshot.evidenceLevel)
         let trend = outlookTrend(snapshot: snapshot)
 
         return VStack(alignment: .leading, spacing: 10) {
@@ -142,7 +142,7 @@ struct HomeView: View {
             }
 
             HStack(alignment: .firstTextBaseline, spacing: 6) {
-                Text(stabilityLabel(score: score))
+                Text(stabilityLabel(score: score, evidenceLevel: snapshot.evidenceLevel))
                     .font(.title3.weight(.bold))
                 Spacer()
                 Text(trend)
@@ -378,6 +378,10 @@ struct HomeView: View {
     }
 
     private func outlookTrend(snapshot: InsightSnapshot) -> String {
+        // With insufficient evidence, "Rising"/"Falling" reads as a confident
+        // short-term claim driven by ≤3 noisy data points. Hold the trend
+        // label at "Gathering" until there's enough recent data to support it.
+        if snapshot.evidenceLevel == .insufficient { return "Gathering trend" }
         guard let avg7 = snapshot.avg7, let avg30 = snapshot.avg30 else { return "Gathering trend" }
         let delta = avg7 - avg30
         if delta > 0.6 { return "Rising" }
@@ -385,13 +389,19 @@ struct HomeView: View {
         return "Stable"
     }
 
-    private func outlookBand(score: Double) -> (label: String, color: Color) {
+    private func outlookBand(score: Double, evidenceLevel: EvidenceLevel) -> (label: String, color: Color) {
+        // The score itself is a noisy 0–100 derived from drift / change-point
+        // posteriors that need a minimum window to be meaningful. Below that
+        // floor, every band reads as overclaiming, so we surface a neutral
+        // "Learning" pill instead.
+        if evidenceLevel == .insufficient { return ("Learning", .gray) }
         if score >= 75 { return ("Rough patch", .red) }
         if score >= 45 { return ("A bit bumpy", .orange) }
         return ("Smooth sailing", .green)
     }
 
-    private func stabilityLabel(score: Double) -> String {
+    private func stabilityLabel(score: Double, evidenceLevel: EvidenceLevel) -> String {
+        if evidenceLevel == .insufficient { return "Still getting to know your patterns" }
         if score >= 75 { return "Pretty turbulent right now" }
         if score >= 45 { return "Some choppiness" }
         if score >= 20 { return "Mostly calm" }
@@ -399,6 +409,11 @@ struct HomeView: View {
     }
 
     private func outlookSummary(snapshot: InsightSnapshot, score: Double) -> String {
+        // Hedge before considering thresholds: a single bad day shouldn't
+        // surface "Things feel choppier than usual" copy.
+        if snapshot.evidenceLevel == .insufficient {
+            return L10n.tr("outlook.summary.learning")
+        }
         // Thresholds intentionally aligned with outlookBand so a single score
         // can't be labeled "Rough patch" by the badge while the supporting
         // summary line says it's only "bumpy".

--- a/moodbound/Views/HomeView.swift
+++ b/moodbound/Views/HomeView.swift
@@ -20,7 +20,11 @@ struct HomeView: View {
                         phaseNudgeCard(snapshot: snapshot)
                     }
                     quickAction
-                    statsGrid
+                    if entries.count < 3 {
+                        baselineCard
+                    } else {
+                        statsGrid
+                    }
                     recentSection
                 }
                 .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
@@ -228,6 +232,28 @@ struct HomeView: View {
         }
     }
 
+    private var baselineCard: some View {
+        let logged = min(entries.count, 3)
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "chart.line.uptrend.xyaxis")
+                    .foregroundStyle(MoodboundDesign.tint)
+                Text("Building your baseline")
+                    .font(.headline)
+            }
+            Text("\(logged) / 3 entries logged. Insights unlock once you've logged 3.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            ProgressView(value: Double(logged), total: 3)
+                .tint(MoodboundDesign.tint)
+            Text("Log once a day for the most useful patterns.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .moodCard()
+    }
+
     private var statsGrid: some View {
         let columns = horizontalSizeClass == .regular
             ? [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
@@ -325,16 +351,18 @@ struct HomeView: View {
     }
 
     private var weekSleepText: String {
-        let cutoff = Calendar.current.date(byAdding: .day, value: -7, to: appNow) ?? appNow
-        let recent = entries.filter { $0.timestamp >= cutoff }
-        guard !recent.isEmpty else { return "No data" }
-        let avg = recent.reduce(0.0) { $0 + $1.sleepHours } / Double(recent.count)
+        // sleepHours == 0 is the "unknown" sentinel; including it would
+        // crater the average. Skip those entries when averaging.
+        let knownSleep = viewModel.entriesWithinDays(entries: entries, days: 7, now: appNow)
+            .map(\.sleepHours)
+            .filter { $0 > 0 }
+        guard !knownSleep.isEmpty else { return "No data" }
+        let avg = knownSleep.reduce(0.0, +) / Double(knownSleep.count)
         return String(format: "%.1f h", avg)
     }
 
     private func entriesInLastDays(_ days: Int) -> Int {
-        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: appNow) ?? appNow
-        return entries.filter { $0.timestamp >= cutoff }.count
+        viewModel.entriesWithinDays(entries: entries, days: days, now: appNow).count
     }
 
     private var insightSnapshot: InsightSnapshot? {
@@ -371,10 +399,13 @@ struct HomeView: View {
     }
 
     private func outlookSummary(snapshot: InsightSnapshot, score: Double) -> String {
-        if score >= 70 {
+        // Thresholds intentionally aligned with outlookBand so a single score
+        // can't be labeled "Rough patch" by the badge while the supporting
+        // summary line says it's only "bumpy".
+        if score >= 75 {
             return L10n.tr("outlook.summary.rough")
         }
-        if score >= 40 {
+        if score >= 45 {
             return L10n.tr("outlook.summary.bumpy")
         }
         if snapshot.lowSleepCount14d > 0 {

--- a/moodbound/Views/InsightsView.swift
+++ b/moodbound/Views/InsightsView.swift
@@ -498,7 +498,7 @@ struct InsightsView: View {
 
     private func outlookCard(snapshot: InsightSnapshot) -> some View {
         let score = outlookScore(snapshot: snapshot)
-        let band = outlookBand(for: score)
+        let band = outlookBand(for: score, evidenceLevel: snapshot.evidenceLevel)
 
         return VStack(alignment: .leading, spacing: 12) {
             HStack {
@@ -514,7 +514,7 @@ struct InsightsView: View {
                     .clipShape(Capsule())
             }
 
-            Text(stabilityLabel(score: score))
+            Text(stabilityLabel(score: score, evidenceLevel: snapshot.evidenceLevel))
                 .font(.title3.weight(.bold))
 
             outcomeMeter(score: score, color: band.color)
@@ -1019,6 +1019,7 @@ struct InsightsView: View {
     }
 
     private func scoreTrend(snapshot: InsightSnapshot) -> String {
+        if snapshot.evidenceLevel == .insufficient { return "Gathering trend" }
         guard let avg7 = snapshot.avg7, let avg30 = snapshot.avg30 else { return "Gathering trend" }
         let delta = avg7 - avg30
         if delta > 0.6 { return "Rising" }
@@ -1027,6 +1028,9 @@ struct InsightsView: View {
     }
 
     private func outlookSummary(snapshot: InsightSnapshot, score: Double) -> String {
+        if snapshot.evidenceLevel == .insufficient {
+            return L10n.tr("outlook.summary.learning")
+        }
         // Thresholds intentionally aligned with outlookBand so a single score
         // can't be labeled "Rough patch" by the badge while the supporting
         // summary line says it's only "bumpy".
@@ -1073,13 +1077,15 @@ struct InsightsView: View {
             .clipShape(Capsule())
     }
 
-    private func outlookBand(for score: Double) -> (label: String, color: Color) {
+    private func outlookBand(for score: Double, evidenceLevel: EvidenceLevel) -> (label: String, color: Color) {
+        if evidenceLevel == .insufficient { return ("Learning", .gray) }
         if score >= 75 { return ("Rough patch", .red) }
         if score >= 45 { return ("A bit bumpy", .orange) }
         return ("Smooth sailing", .green)
     }
 
-    private func stabilityLabel(score: Double) -> String {
+    private func stabilityLabel(score: Double, evidenceLevel: EvidenceLevel) -> String {
+        if evidenceLevel == .insufficient { return "Still getting to know your patterns" }
         if score >= 75 { return "Pretty turbulent right now" }
         if score >= 45 { return "Some choppiness" }
         if score >= 20 { return "Mostly calm" }

--- a/moodbound/Views/InsightsView.swift
+++ b/moodbound/Views/InsightsView.swift
@@ -56,7 +56,7 @@ struct InsightsView: View {
             icon: "flame.fill",
             color: .orange,
             title: "Streak",
-            value: "\(snapshot.streakDays) days"
+            value: "\(snapshot.streakDays) day\(snapshot.streakDays == 1 ? "" : "s")"
         )
 
         if let avg7 = snapshot.avg7 {
@@ -79,7 +79,9 @@ struct InsightsView: View {
             )
         }
 
-        sleepInsight(snapshot: snapshot)
+        if snapshot.lowSleepCount14d > 0 || snapshot.highSleepCount14d > 0 {
+            sleepInsight(snapshot: snapshot)
+        }
 
         if let adherence = snapshot.medicationAdherenceRate14d {
             insightCard(
@@ -103,16 +105,30 @@ struct InsightsView: View {
 
         yourPatternsCard(snapshot: snapshot)
         monthOverMonthCard
-        weatherImpactCard(snapshot: snapshot)
-        warningCard(snapshot: snapshot)
+        if snapshot.weatherCoverageDays >= 7 {
+            weatherImpactCard(snapshot: snapshot)
+        }
+        if snapshot.safety.severity != .none {
+            warningCard(snapshot: snapshot)
+        }
         safetyPlanCard
         modelTransparencyCard(snapshot: snapshot)
         phenotypeCard(snapshot: snapshot)
-        directionalCard(snapshot: snapshot)
-        triggerAttributionCard(snapshot: snapshot)
-        medicationTrajectoryCard(snapshot: snapshot)
-        adaptivePromptCard(snapshot: snapshot)
-        narrativeCard(snapshot: snapshot)
+        if let probe = snapshot.directionalProbes.first, probe.confidence > 0 {
+            directionalCard(snapshot: snapshot, probe: probe)
+        }
+        if let topTrigger = snapshot.triggerAttributions.first {
+            triggerAttributionCard(snapshot: snapshot, top: topTrigger)
+        }
+        if let trajectory = snapshot.medicationTrajectories.first(where: \.isDataSufficient) {
+            medicationTrajectoryCard(snapshot: snapshot, trajectory: trajectory)
+        }
+        if !snapshot.adaptivePrompts.isEmpty {
+            adaptivePromptCard(snapshot: snapshot)
+        }
+        if !snapshot.narrativeCards.isEmpty {
+            narrativeCard(snapshot: snapshot)
+        }
     }
 
     private func insightCard(icon: String, color: Color, title: String, value: String, detail: String? = nil) -> some View {
@@ -143,17 +159,13 @@ struct InsightsView: View {
     }
 
     private func sleepInsight(snapshot: InsightSnapshot) -> some View {
-        return Group {
-            if snapshot.lowSleepCount14d > 0 || snapshot.highSleepCount14d > 0 {
-                insightCard(
-                    icon: "moon.fill",
-                    color: .indigo,
-                    title: "Sleep Pattern (14d)",
-                    value: snapshot.lowSleepCount14d > 0 ? "Under-sleeping" : "Over-sleeping",
-                    detail: sleepDetail(lowSleep: snapshot.lowSleepCount14d, highSleep: snapshot.highSleepCount14d)
-                )
-            }
-        }
+        insightCard(
+            icon: "moon.fill",
+            color: .indigo,
+            title: "Sleep Pattern (14d)",
+            value: snapshot.lowSleepCount14d > 0 ? "Under-sleeping" : "Over-sleeping",
+            detail: sleepDetail(lowSleep: snapshot.lowSleepCount14d, highSleep: snapshot.highSleepCount14d)
+        )
     }
 
     private func sleepDetail(lowSleep: Int, highSleep: Int) -> String {
@@ -168,128 +180,140 @@ struct InsightsView: View {
 
     private func warningCard(snapshot: InsightSnapshot) -> some View {
         let safety = snapshot.safety
-        return Group {
-            if safety.severity != .none {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(MoodboundDesign.accent)
-                        Text("Safety: \(safety.severity.rawValue)")
-                            .font(.headline)
-                    }
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(MoodboundDesign.accent)
+                Text("Safety: \(safety.severity.rawValue)")
+                    .font(.headline)
+            }
 
-                    ForEach(safety.messages, id: \.self) { message in
-                        Text(message)
-                            .font(.subheadline)
-                    }
+            ForEach(safety.messages, id: \.self) { message in
+                Text(message)
+                    .font(.subheadline)
+            }
 
-                    if !safety.recommendedActions.isEmpty {
-                        Text("Recommended actions")
-                            .font(.subheadline.weight(.semibold))
-                            .padding(.top, 4)
-                        ForEach(safety.recommendedActions, id: \.self) { action in
-                            Text("• \(action)")
-                                .font(.subheadline)
-                        }
-                    }
-
-                    HStack(spacing: 16) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Concern Level")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(concernLabel(safety.posteriorRisk))
-                                .font(.headline.weight(.bold))
-                                .foregroundStyle(MoodboundDesign.accent)
-                        }
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Data Confidence")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(confidenceLabel(safety.confidence))
-                                .font(.headline.weight(.bold))
-                                .foregroundStyle(MoodboundDesign.tint)
-                        }
-                    }
-
-                    if let start = safety.evidenceWindowStart, let end = safety.evidenceWindowEnd {
-                        Text("Based on \(start.formatted(date: .abbreviated, time: .omitted)) – \(end.formatted(date: .abbreviated, time: .omitted))")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    if !safety.evidenceSignals.isEmpty {
-                        Text("Evidence")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                        ForEach(safety.evidenceSignals.prefix(3), id: \.self) { signal in
-                            Text("• \(signal)")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-
-                    if let crisisText = safety.crisisBannerText {
-                        Text(crisisText)
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                    }
+            if !safety.recommendedActions.isEmpty {
+                Text("Recommended actions")
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.top, 4)
+                ForEach(safety.recommendedActions, id: \.self) { action in
+                    Text("• \(action)")
+                        .font(.subheadline)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .moodCard()
+            }
+
+            HStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Concern Level")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(concernLabel(safety.posteriorRisk))
+                        .font(.headline.weight(.bold))
+                        .foregroundStyle(MoodboundDesign.accent)
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Data Confidence")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(confidenceLabel(safety.confidence))
+                        .font(.headline.weight(.bold))
+                        .foregroundStyle(MoodboundDesign.tint)
+                }
+            }
+
+            if let start = safety.evidenceWindowStart, let end = safety.evidenceWindowEnd {
+                Text("Based on \(start.formatted(date: .abbreviated, time: .omitted)) – \(end.formatted(date: .abbreviated, time: .omitted))")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !safety.evidenceSignals.isEmpty {
+                Text("Evidence")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(safety.evidenceSignals.prefix(3), id: \.self) { signal in
+                    Text("• \(signal)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if let crisisText = safety.crisisBannerText {
+                Text(crisisText)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .moodCard()
     }
 
+    @ViewBuilder
     private var monthOverMonthCard: some View {
         let calendar = Calendar.current
         let now = appNow
 
-        // Split entries into this-month (last 30d) and prior-month (31–60d ago).
-        let cutoff30 = calendar.date(byAdding: .day, value: -30, to: now) ?? now
-        let cutoff60 = calendar.date(byAdding: .day, value: -60, to: now) ?? now
-        let thisMonth = entries.filter { $0.timestamp >= cutoff30 && $0.timestamp <= now }
-        let lastMonth = entries.filter { $0.timestamp >= cutoff60 && $0.timestamp < cutoff30 }
+        // Split entries into two equal-length 30-day windows anchored on
+        // calendar day boundaries. The previous implementation used wall-clock
+        // subtraction (`now - 30d`, `now - 60d`) and an inclusive upper bound
+        // for this-month, which made this-month a 31-day window while
+        // last-month was 30 — biasing the comparison.
+        let startToday = calendar.startOfDay(for: now)
+        let upperThis = calendar.date(byAdding: .day, value: 1, to: startToday) ?? startToday
+        let lowerThis = calendar.date(byAdding: .day, value: -29, to: startToday) ?? startToday
+        let lowerLast = calendar.date(byAdding: .day, value: -59, to: startToday) ?? startToday
+        let thisMonth = entries.filter { $0.timestamp >= lowerThis && $0.timestamp < upperThis }
+        let lastMonth = entries.filter { $0.timestamp >= lowerLast && $0.timestamp < lowerThis }
 
-        return Group {
-            if thisMonth.count >= 5 && lastMonth.count >= 5 {
-                let thisAvg = Double(thisMonth.reduce(0) { $0 + $1.moodLevel }) / Double(thisMonth.count)
-                let lastAvg = Double(lastMonth.reduce(0) { $0 + $1.moodLevel }) / Double(lastMonth.count)
-                let delta = thisAvg - lastAvg
+        if thisMonth.count >= 5 && lastMonth.count >= 5 {
+            let thisAvg = Double(thisMonth.reduce(0) { $0 + $1.moodLevel }) / Double(thisMonth.count)
+            let lastAvg = Double(lastMonth.reduce(0) { $0 + $1.moodLevel }) / Double(lastMonth.count)
+            let delta = thisAvg - lastAvg
 
-                let thisSleep = thisMonth.reduce(0.0) { $0 + $1.sleepHours } / Double(thisMonth.count)
-                let lastSleep = lastMonth.reduce(0.0) { $0 + $1.sleepHours } / Double(lastMonth.count)
-                let sleepDelta = thisSleep - lastSleep
+            // sleepHours == 0 is the "unknown" sentinel; exclude those entries
+            // so users who skipped logging sleep don't drag their monthly
+            // average to absurd values.
+            let thisSleepKnown = thisMonth.map(\.sleepHours).filter { $0 > 0 }
+            let lastSleepKnown = lastMonth.map(\.sleepHours).filter { $0 > 0 }
+            let thisSleep = thisSleepKnown.isEmpty
+                ? nil
+                : thisSleepKnown.reduce(0.0, +) / Double(thisSleepKnown.count)
+            let lastSleep = lastSleepKnown.isEmpty
+                ? nil
+                : lastSleepKnown.reduce(0.0, +) / Double(lastSleepKnown.count)
+            let sleepDelta: Double? = (thisSleep != nil && lastSleep != nil) ? (thisSleep! - lastSleep!) : nil
 
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "calendar.badge.clock")
-                            .foregroundStyle(.blue)
-                        Text("This Month vs Last")
-                            .font(.headline)
-                    }
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 6) {
+                    Image(systemName: "calendar.badge.clock")
+                        .foregroundStyle(.blue)
+                    Text("This Month vs Last")
+                        .font(.headline)
+                }
 
-                    HStack(spacing: 20) {
-                        comparisonStat(
-                            label: "Avg Mood",
-                            delta: delta,
-                            format: { String(format: "%+.1f", $0) }
-                        )
+                HStack(spacing: 20) {
+                    comparisonStat(
+                        label: "Avg Mood",
+                        delta: delta,
+                        format: { String(format: "%+.1f", $0) }
+                    )
+                    if let sleepDelta {
                         comparisonStat(
                             label: "Avg Sleep",
                             delta: sleepDelta,
                             format: { String(format: "%+.1fh", $0) }
                         )
-                        comparisonStat(
-                            label: "Entries",
-                            delta: Double(thisMonth.count - lastMonth.count),
-                            format: { String(format: "%+.0f", $0) }
-                        )
                     }
+                    comparisonStat(
+                        label: "Entries",
+                        delta: Double(thisMonth.count - lastMonth.count),
+                        format: { String(format: "%+.0f", $0) }
+                    )
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .moodCard()
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .moodCard()
         }
     }
 
@@ -314,30 +338,29 @@ struct InsightsView: View {
         return delta > 0 ? .green : .orange
     }
 
+    @ViewBuilder
     private func yourPatternsCard(snapshot: InsightSnapshot) -> some View {
         let stories = patternStories(snapshot: snapshot)
-        return Group {
-            if !stories.isEmpty {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "sparkle.magnifyingglass")
-                            .foregroundStyle(MoodboundDesign.tint)
-                        Text("Your Patterns")
-                            .font(.headline)
-                    }
-
-                    ForEach(stories, id: \.self) { story in
-                        Text(story)
-                            .font(.subheadline)
-                    }
-
-                    Text("Based on your logged data — patterns, not diagnoses.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+        if !stories.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 6) {
+                    Image(systemName: "sparkle.magnifyingglass")
+                        .foregroundStyle(MoodboundDesign.tint)
+                    Text("Your Patterns")
+                        .font(.headline)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .moodCard()
+
+                ForEach(stories, id: \.self) { story in
+                    Text(story)
+                        .font(.subheadline)
+                }
+
+                Text("Based on your logged data — patterns, not diagnoses.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .moodCard()
         }
     }
 
@@ -410,62 +433,57 @@ struct InsightsView: View {
         .accessibilityIdentifier("open-safety-plan-button")
         .moodCard()
     }
-    }
 
     private func weatherImpactCard(snapshot: InsightSnapshot) -> some View {
-        Group {
-            if snapshot.weatherCoverageDays >= 7 {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Weather & Mood")
-                        .font(.headline)
-                    Text("\(snapshot.weatherCoverageDays)-day weather timeline\(snapshot.weatherCity.map { " for \($0)" } ?? "")")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Weather & Mood")
+                .font(.headline)
+            Text("\(snapshot.weatherCoverageDays)-day weather timeline\(snapshot.weatherCity.map { " for \($0)" } ?? "")")
+                .font(.caption)
+                .foregroundStyle(.secondary)
 
-                    if let rainyDelta = snapshot.rainyMoodDelta {
-                        HStack(spacing: 8) {
-                            Text("🌧")
-                                .font(.title2)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(weatherEffectLabel("Rain", delta: rainyDelta))
-                                    .font(.subheadline.weight(.bold))
-                                Text(rainyDelta < -0.3
-                                     ? "Your mood tends to dip on rainy days."
-                                     : rainyDelta > 0.3
-                                     ? "Rain actually seems to help your mood."
-                                     : "Rainy days don't seem to affect you much.")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    } else {
-                        weatherGatheringHint("rain vs. clear sky")
-                    }
-
-                    if let hotDelta = snapshot.hotMoodDelta {
-                        HStack(spacing: 8) {
-                            Text("🌡️")
-                                .font(.title2)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(weatherEffectLabel("Heat", delta: hotDelta))
-                                    .font(.subheadline.weight(.bold))
-                                Text(hotDelta > 0.3
-                                     ? "Hot days seem to amp you up a bit."
-                                     : hotDelta < -0.3
-                                     ? "Heat tends to bring your mood down."
-                                     : "Heat doesn't seem to affect your mood much.")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    } else {
-                        weatherGatheringHint("hot vs. mild days")
+            if let rainyDelta = snapshot.rainyMoodDelta {
+                HStack(spacing: 8) {
+                    Text("🌧")
+                        .font(.title2)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(weatherEffectLabel("Rain", delta: rainyDelta))
+                            .font(.subheadline.weight(.bold))
+                        Text(rainyDelta < -0.3
+                             ? "Your mood tends to dip on rainy days."
+                             : rainyDelta > 0.3
+                             ? "Rain actually seems to help your mood."
+                             : "Rainy days don't seem to affect you much.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .moodCard()
+            } else {
+                weatherGatheringHint("rain vs. clear sky")
+            }
+
+            if let hotDelta = snapshot.hotMoodDelta {
+                HStack(spacing: 8) {
+                    Text("🌡️")
+                        .font(.title2)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(weatherEffectLabel("Heat", delta: hotDelta))
+                            .font(.subheadline.weight(.bold))
+                        Text(hotDelta > 0.3
+                             ? "Hot days seem to amp you up a bit."
+                             : hotDelta < -0.3
+                             ? "Heat tends to bring your mood down."
+                             : "Heat doesn't seem to affect your mood much.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } else {
+                weatherGatheringHint("hot vs. mild days")
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .moodCard()
     }
 
     private func weatherGatheringHint(_ comparison: String) -> some View {
@@ -481,7 +499,6 @@ struct InsightsView: View {
     private func outlookCard(snapshot: InsightSnapshot) -> some View {
         let score = outlookScore(snapshot: snapshot)
         let band = outlookBand(for: score)
-        let trend = scoreTrend(snapshot: snapshot)
 
         return VStack(alignment: .leading, spacing: 12) {
             HStack {
@@ -704,9 +721,10 @@ struct InsightsView: View {
             return "Holding steady"
         case "recovery-half-life":
             let days = card.metricValue
-            if days <= 2 { return "Fast — about \(Int(days.rounded())) day\(days <= 1.5 ? "" : "s")" }
+            let rounded = Int(days.rounded())
+            if days <= 2 { return "Fast — about \(rounded) day\(rounded == 1 ? "" : "s")" }
             if days <= 5 { return "A few days" }
-            return "Takes a while — \(Int(days.rounded())) days"
+            return "Takes a while — \(rounded) days"
         default:
             return card.interpretationBand
         }
@@ -745,42 +763,38 @@ struct InsightsView: View {
         }
     }
 
-    private func directionalCard(snapshot: InsightSnapshot) -> some View {
-        Group {
-            if let probe = snapshot.directionalProbes.first, probe.confidence > 0 {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Connection Spotted")
-                        .font(.headline)
-                    Text("\(probe.source) → \(probe.target)")
-                        .font(.title3.weight(.bold))
+    private func directionalCard(snapshot: InsightSnapshot, probe: DirectionalSignalProbe) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Connection Spotted")
+                .font(.headline)
+            Text("\(probe.source) → \(probe.target)")
+                .font(.title3.weight(.bold))
 
-                    HStack(spacing: 16) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Strength")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(connectionStrengthLabel(probe.strength))
-                                .font(.title2.weight(.bold))
-                                .foregroundStyle(connectionStrengthColor(probe.strength))
-                        }
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Confidence")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text("\(Int((probe.confidence * 100).rounded()))%")
-                                .font(.title2.weight(.bold))
-                                .foregroundStyle(MoodboundDesign.tint)
-                        }
-                    }
-
-                    Text("This is a pattern in your data, not a diagnosis or proof of cause and effect. Use it as a conversation starter with your care team.")
+            HStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Strength")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    Text(connectionStrengthLabel(probe.strength))
+                        .font(.title2.weight(.bold))
+                        .foregroundStyle(connectionStrengthColor(probe.strength))
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .moodCard()
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Confidence")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("\(Int((probe.confidence * 100).rounded()))%")
+                        .font(.title2.weight(.bold))
+                        .foregroundStyle(MoodboundDesign.tint)
+                }
             }
+
+            Text("This is a pattern in your data, not a diagnosis or proof of cause and effect. Use it as a conversation starter with your care team.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .moodCard()
     }
 
     private func connectionStrengthLabel(_ strength: Double) -> String {
@@ -798,72 +812,64 @@ struct InsightsView: View {
         return .green
     }
 
-    private func triggerAttributionCard(snapshot: InsightSnapshot) -> some View {
-        Group {
-            if let top = snapshot.triggerAttributions.first {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Biggest Trigger")
-                        .font(.headline)
-                    Text(top.triggerName)
-                        .font(.title2.weight(.bold))
-                    HStack(spacing: 4) {
-                        Text("\(Int((top.confidence * 100).rounded()))%")
-                            .font(.title.weight(.bold))
-                            .foregroundStyle(MoodboundDesign.tint)
-                        Text("match")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                    Text("Based on \(top.evidenceWindowStart.formatted(date: .abbreviated, time: .omitted)) – \(top.evidenceWindowEnd.formatted(date: .abbreviated, time: .omitted))")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    Text("This shows which factor appeared most often alongside mood changes — it's a pattern, not a cause.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .moodCard()
+    private func triggerAttributionCard(snapshot: InsightSnapshot, top: TriggerAttribution) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Biggest Trigger")
+                .font(.headline)
+            Text(top.triggerName)
+                .font(.title2.weight(.bold))
+            HStack(spacing: 4) {
+                Text("\(Int((top.confidence * 100).rounded()))%")
+                    .font(.title.weight(.bold))
+                    .foregroundStyle(MoodboundDesign.tint)
+                Text("match")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
             }
+            Text("Based on \(top.evidenceWindowStart.formatted(date: .abbreviated, time: .omitted)) – \(top.evidenceWindowEnd.formatted(date: .abbreviated, time: .omitted))")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("This shows which factor appeared most often alongside mood changes — it's a pattern, not a cause.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .moodCard()
     }
 
-    private func medicationTrajectoryCard(snapshot: InsightSnapshot) -> some View {
-        Group {
-            if let trajectory = snapshot.medicationTrajectories.first(where: \.isDataSufficient) {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Medication Effect")
-                        .font(.headline)
-                    Text(trajectory.medicationName)
-                        .font(.title3.weight(.bold))
+    private func medicationTrajectoryCard(snapshot: InsightSnapshot, trajectory: MedicationTrajectory) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Medication Effect")
+                .font(.headline)
+            Text(trajectory.medicationName)
+                .font(.title3.weight(.bold))
 
-                    HStack(spacing: 16) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Past few days")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(medEffectLabel(trajectory.shortWindowDelta))
-                                .font(.headline.weight(.bold))
-                                .foregroundStyle(medEffectColor(trajectory.shortWindowDelta))
-                        }
-                        Spacer()
-                        VStack(alignment: .trailing, spacing: 2) {
-                            Text("Past few weeks")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(medEffectLabel(trajectory.mediumWindowDelta))
-                                .font(.headline.weight(.bold))
-                                .foregroundStyle(medEffectColor(trajectory.mediumWindowDelta))
-                        }
-                    }
-
-                    Text("Compares your stability on days you took this medication vs. days you missed it.")
+            HStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Past few days")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    Text(medEffectLabel(trajectory.shortWindowDelta))
+                        .font(.headline.weight(.bold))
+                        .foregroundStyle(medEffectColor(trajectory.shortWindowDelta))
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .moodCard()
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("Past few weeks")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(medEffectLabel(trajectory.mediumWindowDelta))
+                        .font(.headline.weight(.bold))
+                        .foregroundStyle(medEffectColor(trajectory.mediumWindowDelta))
+                }
             }
+
+            Text("Compares your stability on days you took this medication vs. days you missed it.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .moodCard()
     }
 
     private func medEffectLabel(_ delta: Double) -> String {
@@ -881,39 +887,35 @@ struct InsightsView: View {
     }
 
     private func adaptivePromptCard(snapshot: InsightSnapshot) -> some View {
-        Group {
-            if !snapshot.adaptivePrompts.isEmpty {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack {
-                        Image(systemName: "lightbulb.fill")
-                            .foregroundStyle(.yellow)
-                        Text("Try This Next Time")
-                            .font(.headline)
-                    }
-                    Text("These questions can help fill in gaps in your data:")
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Image(systemName: "lightbulb.fill")
+                    .foregroundStyle(.yellow)
+                Text("Try This Next Time")
+                    .font(.headline)
+            }
+            Text("These questions can help fill in gaps in your data:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            ForEach(snapshot.adaptivePrompts.prefix(2)) { prompt in
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(prompt.title)
+                        .font(.subheadline.weight(.bold))
+                    Text(prompt.prompt)
+                        .font(.subheadline)
+                    Text(prompt.rationale)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-
-                    ForEach(snapshot.adaptivePrompts.prefix(2)) { prompt in
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(prompt.title)
-                                .font(.subheadline.weight(.bold))
-                            Text(prompt.prompt)
-                                .font(.subheadline)
-                            Text(prompt.rationale)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(10)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(MoodboundDesign.tint.opacity(0.06))
-                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                    }
                 }
+                .padding(10)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .moodCard()
+                .background(MoodboundDesign.tint.opacity(0.06))
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .moodCard()
     }
 
     /// B4: Render all narrative cards the composer produced (safety,
@@ -923,43 +925,39 @@ struct InsightsView: View {
     /// the safety card. Body text is already sanitized by
     /// SafetyCopyPolicy inside the composer.
     private func narrativeCard(snapshot: InsightSnapshot) -> some View {
-        Group {
-            if !snapshot.narrativeCards.isEmpty {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("What we're seeing")
-                        .font(.headline)
+        VStack(alignment: .leading, spacing: 12) {
+            Text("What we're seeing")
+                .font(.headline)
 
-                    ForEach(snapshot.narrativeCards) { narrative in
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 6) {
-                                Image(systemName: narrativeIcon(for: narrative.id))
-                                    .foregroundStyle(narrativeColor(for: narrative.id))
-                                Text(narrative.title)
-                                    .font(.subheadline.weight(.semibold))
-                            }
-                            Text(narrative.body)
-                                .font(.subheadline)
-                            HStack(spacing: 12) {
-                                Text(confidenceLabel(narrative.confidence))
-                                    .font(.caption.weight(.bold))
-                                    .foregroundStyle(MoodboundDesign.tint)
-                                Text(narrative.evidenceWindow)
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-
-                        if narrative.id != snapshot.narrativeCards.last?.id {
-                            Divider()
-                        }
+            ForEach(snapshot.narrativeCards) { narrative in
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 6) {
+                        Image(systemName: narrativeIcon(for: narrative.id))
+                            .foregroundStyle(narrativeColor(for: narrative.id))
+                        Text(narrative.title)
+                            .font(.subheadline.weight(.semibold))
+                    }
+                    Text(narrative.body)
+                        .font(.subheadline)
+                    HStack(spacing: 12) {
+                        Text(confidenceLabel(narrative.confidence))
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(MoodboundDesign.tint)
+                        Text(narrative.evidenceWindow)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .moodCard()
-                .accessibilityIdentifier("insights-narrative-card")
+
+                if narrative.id != snapshot.narrativeCards.last?.id {
+                    Divider()
+                }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .moodCard()
+        .accessibilityIdentifier("insights-narrative-card")
     }
 
     private func narrativeIcon(for id: String) -> String {
@@ -1029,10 +1027,13 @@ struct InsightsView: View {
     }
 
     private func outlookSummary(snapshot: InsightSnapshot, score: Double) -> String {
-        if score >= 70 {
+        // Thresholds intentionally aligned with outlookBand so a single score
+        // can't be labeled "Rough patch" by the badge while the supporting
+        // summary line says it's only "bumpy".
+        if score >= 75 {
             return L10n.tr("outlook.summary.rough")
         }
-        if score >= 40 {
+        if score >= 45 {
             return L10n.tr("outlook.summary.bumpy")
         }
         if snapshot.lowSleepCount14d > 0 {

--- a/moodbound/Views/NewEntryView.swift
+++ b/moodbound/Views/NewEntryView.swift
@@ -27,12 +27,21 @@ struct NewEntryView: View {
     @State private var newlyAddedTriggers: Set<String> = []
     @State private var showingSaveError = false
     @State private var saveErrorMessage = ""
+    @State private var showingZeroSleepConfirm = false
+    @State private var healthKitSleepLookupMessage: String?
     @State private var savedFeedback: SavedFeedback?
     @State private var didApplyDefaults = false
     @State private var currentWeather: OpenMeteoWeatherService.CurrentWeather?
     @State private var weatherStatus: WeatherFetchStatus = .idle
     @State private var weatherExplicitlyRemoved = false
     @State private var locationService = LocationService()
+    @State private var manualEntryMode: ManualWeatherEntryMode = .none
+    @State private var cityInput: String = ""
+    @State private var cityLookupInFlight: Bool = false
+    @State private var cityLookupError: String?
+    @State private var manualCondition: ManualWeatherCondition = .clear
+    @State private var manualTemperature: String = ""
+    @State private var manualCity: String = ""
     @State private var sleepSource: SleepSource = .manual
     @State private var restingHeartRate: Double?
     @State private var hrvSDNN: Double?
@@ -156,33 +165,35 @@ struct NewEntryView: View {
                     Text("Energy Level")
                 }
 
-                Section {
-                    HStack {
-                        Image(systemName: "moon.fill")
-                            .foregroundStyle(.indigo)
-                        Slider(value: $sleepHours, in: 0...16, step: 0.5)
-                            .accessibilityLabel("Sleep hours")
-                            .accessibilityValue("\(String(format: "%.1f", sleepHours)) hours")
-                        Text(String(format: "%.1fh", sleepHours))
-                            .monospacedDigit()
-                            .frame(width: 44)
-                    }
-                    if sleepSource == .healthKit {
-                        HStack(spacing: 6) {
-                            Image(systemName: "heart.fill")
-                                .foregroundStyle(.red)
-                                .font(.caption)
-                            Text("From Apple Health — adjust if needed")
+                if shouldShowSleepSection {
+                    Section {
+                        HStack {
+                            Image(systemName: "moon.fill")
+                                .foregroundStyle(.indigo)
+                            Slider(value: $sleepHours, in: 0...16, step: 0.5)
+                                .accessibilityLabel("Sleep hours")
+                                .accessibilityValue("\(String(format: "%.1f", sleepHours)) hours")
+                            Text(String(format: "%.1fh", sleepHours))
+                                .monospacedDigit()
+                                .frame(width: 44)
+                        }
+                        if sleepSource == .healthKit {
+                            HStack(spacing: 6) {
+                                Image(systemName: "heart.fill")
+                                    .foregroundStyle(.red)
+                                    .font(.caption)
+                                Text("From Apple Health — adjust if needed")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } else {
+                            Text("How much sleep did you get last night?")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
-                    } else {
-                        Text(hasLoggedSleepToday ? "Include naps or additional rest since your last check-in. Set to 0 if none." : "How much sleep did you get last night?")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                    } header: {
+                        Text("Sleep")
                     }
-                } header: {
-                    Text("Sleep")
                 }
 
                 Section {
@@ -319,6 +330,31 @@ struct NewEntryView: View {
             } message: {
                 Text(saveErrorMessage)
             }
+            .alert("0 hours of sleep?", isPresented: $showingZeroSleepConfirm) {
+                if healthKitSleepEnabled {
+                    Button("Use Apple Health") {
+                        Task { await fillSleepFromHealthKitAndSave() }
+                    }
+                }
+                Button("Yes, that's right") {
+                    saveAndDismiss(bypassZeroSleepCheck: true)
+                }
+                Button("Edit", role: .cancel) {}
+            } message: {
+                if healthKitSleepEnabled {
+                    Text("Everyone has to sleep — this looks unlikely. You can pull last night's sleep from Apple Health, confirm 0 hours is correct, or edit the value.")
+                } else {
+                    Text("Everyone has to sleep — this looks unlikely. Confirm 0 hours is correct, or edit the value. Enable Apple Health in Settings to import sleep.")
+                }
+            }
+            .alert("Apple Health", isPresented: Binding(
+                get: { healthKitSleepLookupMessage != nil },
+                set: { if !$0 { healthKitSleepLookupMessage = nil } }
+            )) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(healthKitSleepLookupMessage ?? "")
+            }
             .overlay {
                 if let feedback = savedFeedback {
                     savedFeedbackOverlay(feedback)
@@ -329,7 +365,27 @@ struct NewEntryView: View {
         }
     }
 
-    private func saveAndDismiss() {
+    private func saveAndDismiss(bypassZeroSleepCheck: Bool = false) {
+        // When the sleep section is hidden, ensure the saved record matches
+        // today's authoritative sleep value rather than whatever the slider
+        // happened to be initialized to. This is belt-and-suspenders against
+        // a save firing before applySmartDefaults runs.
+        if entryToEdit == nil, !shouldShowSleepSection,
+           let inherited = todaysAuthoritativeSleepHours {
+            sleepHours = inherited
+        }
+
+        // Guardrail: 0-hour sleep is almost certainly wrong ("everyone has to
+        // sleep"). Block the save and let the user reconsider, optionally
+        // pulling from Apple Health. Skipped when the section is hidden
+        // because the value was inherited from today's authoritative entry,
+        // which we already validated as > 0.
+        if !bypassZeroSleepCheck, shouldShowSleepSection, sleepHours <= 0 {
+            healthKitSleepLookupMessage = nil
+            showingZeroSleepConfirm = true
+            return
+        }
+
         let saveTimestamp = timestamp
         let saveMoodLevel = moodLevel
         let weatherPayload = NewEntryWeatherPersistence.resolve(
@@ -421,15 +477,34 @@ struct NewEntryView: View {
         }
     }
 
+    /// Triggered from the 0-hour sleep guardrail when the user picks
+    /// "Use Apple Health". Fetches last night's sleep; if found, applies it
+    /// and proceeds with the save bypassing the guardrail. If Apple Health
+    /// has nothing, surfaces an inline alert and stays on the form.
+    private func fillSleepFromHealthKitAndSave() async {
+        if let hours = await HealthKitService.fetchLastNightSleepHours(), hours > 0 {
+            sleepHours = hours
+            sleepSource = .healthKit
+            saveAndDismiss(bypassZeroSleepCheck: true)
+        } else {
+            healthKitSleepLookupMessage = "No sleep data in Apple Health for last night."
+        }
+    }
+
     private func applySmartDefaults() {
-        guard entryToEdit == nil, !didApplyDefaults, let last = recentEntries.first else { return }
+        guard entryToEdit == nil, !didApplyDefaults else { return }
         didApplyDefaults = true
 
-        if hasLoggedSleepToday {
-            sleepHours = 0
-        } else {
-            sleepHours = last.sleepHours
+        // Sleep: if today already has an authoritative entry with sleep > 0,
+        // inherit its value so the new entry's saved record matches the rest
+        // of today's records. Sleep is intentionally NOT carried across days
+        // — stale values from prior days were producing wrong saves when the
+        // user didn't touch the slider.
+        if let inherited = todaysAuthoritativeSleepHours {
+            sleepHours = inherited
         }
+
+        guard let last = recentEntries.first else { return }
         energy = last.energy
 
         // Carry forward active medications from last entry
@@ -585,6 +660,40 @@ struct NewEntryView: View {
         return recentEntries.contains { calendar.startOfDay(for: $0.timestamp) == todayStart }
     }
 
+    /// Sleep is fundamentally a once-per-night measurement, but we store it
+    /// per entry. To keep the day's records consistent, we treat the sleep
+    /// value from the FIRST entry on the same calendar day as authoritative
+    /// for the whole day — subsequent entries inherit it instead of asking
+    /// the user to remember and re-type.
+    ///
+    /// Excludes the entry being edited so editing the first-of-day entry
+    /// still shows its own value (and lets the user change it).
+    /// Returns nil if no other entry on the same calendar day exists, or if
+    /// the existing value is 0 (treated as bad data — don't propagate it).
+    private var todaysAuthoritativeSleepHours: Double? {
+        let calendar = Calendar.current
+        let dayStart = calendar.startOfDay(for: timestamp)
+        let editingID = entryToEdit?.persistentModelID
+        let sameDayOthers = recentEntries.filter {
+            calendar.startOfDay(for: $0.timestamp) == dayStart && $0.persistentModelID != editingID
+        }
+        // Earliest entry of the day is the authoritative one.
+        guard let earliest = sameDayOthers.min(by: { $0.timestamp < $1.timestamp }) else {
+            return nil
+        }
+        guard earliest.sleepHours > 0 else { return nil }
+        return earliest.sleepHours
+    }
+
+    /// Hide the sleep section when (a) we're creating a new entry, (b) today
+    /// already has an authoritative sleep value, and (c) that value is > 0.
+    /// Editing an existing entry always shows the section so the user can
+    /// correct that specific entry's record.
+    private var shouldShowSleepSection: Bool {
+        if entryToEdit != nil { return true }
+        return todaysAuthoritativeSleepHours == nil
+    }
+
     private var newlyAddedTriggerNames: [String] {
         let existingNormalized = Set(allTriggers.map(\.normalizedName))
         return newlyAddedTriggers
@@ -611,15 +720,18 @@ struct NewEntryView: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("\(w.summary), \(formattedTemperature(w.temperatureC))")
                                 .font(.subheadline.weight(.semibold))
-                            Text(w.city)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                            if !w.city.isEmpty {
+                                Text(w.city)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                         Spacer()
                         Button {
                             currentWeather = nil
                             weatherStatus = .skipped
                             weatherExplicitlyRemoved = true
+                            manualEntryMode = .none
                         } label: {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundStyle(.secondary)
@@ -632,10 +744,11 @@ struct NewEntryView: View {
                 HStack(spacing: 8) {
                     Image(systemName: "location.slash")
                         .foregroundStyle(.secondary)
-                    Text("Location access needed for weather")
+                    Text("Location off — set weather another way")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
+                manualEntryControls(includeRetry: false)
             case .failed:
                 HStack(spacing: 8) {
                     Image(systemName: "cloud.slash")
@@ -643,21 +756,157 @@ struct NewEntryView: View {
                     Text("Couldn't load weather")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
-                    Spacer()
-                    Button("Retry") {
-                        weatherStatus = .idle
-                        Task { await fetchWeatherIfNeeded() }
-                    }
-                    .font(.subheadline)
                 }
+                manualEntryControls(includeRetry: true)
             case .skipped:
-                EmptyView()
+                Button {
+                    weatherExplicitlyRemoved = false
+                    weatherStatus = .denied
+                    manualEntryMode = .none
+                } label: {
+                    Label("Add weather", systemImage: "plus.circle")
+                        .font(.subheadline)
+                }
             }
         } header: {
-            if weatherStatus != .skipped {
-                Text("Weather")
-            }
+            Text("Weather")
         }
+    }
+
+    @ViewBuilder
+    private func manualEntryControls(includeRetry: Bool) -> some View {
+        switch manualEntryMode {
+        case .none:
+            if includeRetry {
+                Button {
+                    weatherStatus = .idle
+                    Task { await fetchWeatherIfNeeded() }
+                } label: {
+                    Label("Retry with location", systemImage: "arrow.clockwise")
+                        .font(.subheadline)
+                }
+            }
+            Button {
+                cityLookupError = nil
+                manualEntryMode = .city
+            } label: {
+                Label("Enter a city", systemImage: "magnifyingglass")
+                    .font(.subheadline)
+            }
+            Button {
+                manualEntryMode = .manual
+            } label: {
+                Label("Set weather manually", systemImage: "pencil")
+                    .font(.subheadline)
+            }
+        case .city:
+            HStack {
+                TextField("City (e.g. Boston)", text: $cityInput)
+                    .textInputAutocapitalization(.words)
+                    .autocorrectionDisabled()
+                    .submitLabel(.search)
+                    .onSubmit { Task { await submitCityLookup() } }
+                if cityLookupInFlight {
+                    ProgressView()
+                } else if !cityInput.trimmingCharacters(in: .whitespaces).isEmpty {
+                    Button {
+                        Task { await submitCityLookup() }
+                    } label: {
+                        Image(systemName: "arrow.right.circle.fill")
+                            .foregroundStyle(MoodboundDesign.tint)
+                    }
+                }
+            }
+            if let err = cityLookupError {
+                Text(err)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+            Button("Cancel") {
+                manualEntryMode = .none
+                cityInput = ""
+                cityLookupError = nil
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        case .manual:
+            Picker("Conditions", selection: $manualCondition) {
+                ForEach(ManualWeatherCondition.allCases) { condition in
+                    Text("\(condition.emoji)  \(condition.rawValue)")
+                        .tag(condition)
+                }
+            }
+            HStack {
+                Text(usesMetric ? "Temperature (°C)" : "Temperature (°F)")
+                Spacer()
+                TextField(usesMetric ? "20" : "68", text: $manualTemperature)
+                    .keyboardType(.numbersAndPunctuation)
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 80)
+            }
+            TextField("Place (optional)", text: $manualCity)
+                .textInputAutocapitalization(.words)
+            Button("Save weather") {
+                applyManualWeather()
+            }
+            .disabled(parsedManualTemperature == nil)
+            Button("Cancel") {
+                manualEntryMode = .none
+                manualTemperature = ""
+                manualCity = ""
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private func submitCityLookup() async {
+        let trimmed = cityInput.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, !cityLookupInFlight else { return }
+        cityLookupInFlight = true
+        cityLookupError = nil
+        defer { cityLookupInFlight = false }
+        do {
+            let location = try await OpenMeteoWeatherService.geocodeCity(trimmed)
+            let weather = try await OpenMeteoWeatherService.fetchCurrentWeather(location: location)
+            currentWeather = weather
+            weatherStatus = .success
+            weatherExplicitlyRemoved = false
+            manualEntryMode = .none
+            cityInput = ""
+        } catch OpenMeteoWeatherService.WeatherError.noLocationFound {
+            cityLookupError = "Couldn't find that city. Try a different spelling."
+        } catch {
+            AppLogger.error("Manual city weather fetch failed", error: error)
+            cityLookupError = "Couldn't reach the weather service. Try again."
+        }
+    }
+
+    private func applyManualWeather() {
+        guard let celsius = parsedManualTemperature else { return }
+        let cityName = manualCity.trimmingCharacters(in: .whitespaces)
+        currentWeather = OpenMeteoWeatherService.CurrentWeather(
+            city: cityName,
+            weatherCode: manualCondition.weatherCode,
+            temperatureC: celsius,
+            precipitationMM: 0,
+            summary: manualCondition.rawValue
+        )
+        weatherStatus = .success
+        weatherExplicitlyRemoved = false
+        manualEntryMode = .none
+        manualTemperature = ""
+        manualCity = ""
+    }
+
+    private var parsedManualTemperature: Double? {
+        let trimmed = manualTemperature.trimmingCharacters(in: .whitespaces)
+        guard let value = Double(trimmed) else { return nil }
+        return usesMetric ? value : ((value - 32) * 5.0 / 9.0)
+    }
+
+    private var usesMetric: Bool {
+        Locale.current.measurementSystem == .metric
     }
 
     private func fetchWeatherIfNeeded() async {
@@ -868,6 +1117,52 @@ enum WeatherFetchStatus {
 
 enum SleepSource {
     case manual, healthKit
+}
+
+enum ManualWeatherEntryMode {
+    case none, city, manual
+}
+
+enum ManualWeatherCondition: String, CaseIterable, Identifiable {
+    case clear = "Clear"
+    case partlyCloudy = "Partly cloudy"
+    case cloudy = "Cloudy"
+    case fog = "Fog"
+    case drizzle = "Drizzle"
+    case rain = "Rain"
+    case snow = "Snow"
+    case thunderstorm = "Thunderstorm"
+
+    var id: String { rawValue }
+
+    // Picks a representative Open-Meteo WMO weather code for each
+    // user-facing category so downstream rendering (emoji, summary) uses
+    // the same path as API-sourced weather.
+    var weatherCode: Int {
+        switch self {
+        case .clear: return 0
+        case .partlyCloudy: return 2
+        case .cloudy: return 3
+        case .fog: return 45
+        case .drizzle: return 51
+        case .rain: return 61
+        case .snow: return 71
+        case .thunderstorm: return 95
+        }
+    }
+
+    var emoji: String {
+        switch self {
+        case .clear: return "☀️"
+        case .partlyCloudy: return "🌤️"
+        case .cloudy: return "☁️"
+        case .fog: return "🌫️"
+        case .drizzle: return "🌦️"
+        case .rain: return "🌧️"
+        case .snow: return "❄️"
+        case .thunderstorm: return "⛈️"
+        }
+    }
 }
 
 struct MoodSlider: View {

--- a/moodbound/Views/NewEntryView.swift
+++ b/moodbound/Views/NewEntryView.swift
@@ -761,8 +761,9 @@ struct NewEntryView: View {
             case .skipped:
                 Button {
                     weatherExplicitlyRemoved = false
-                    weatherStatus = .denied
                     manualEntryMode = .none
+                    weatherStatus = .idle
+                    Task { await fetchWeatherIfNeeded() }
                 } label: {
                     Label("Add weather", systemImage: "plus.circle")
                         .font(.subheadline)

--- a/moodboundTests/BayesianSafetyEngineTests.swift
+++ b/moodboundTests/BayesianSafetyEngineTests.swift
@@ -79,6 +79,37 @@ final class BayesianSafetyEngineTests: XCTestCase {
             "Posterior should rise meaningfully above the prior, not collapse back into it")
     }
 
+    // Regression: sleepHours == 0 is the app's "unknown" sentinel (HealthKit
+    // miss or user skipped). Previously lowSleepRate was computed as
+    // `$0.sleepHours < 6.0`, which treated a run of unlogged days as 14 days
+    // of severe sleep deficit and inflated posteriorRisk. Two parallel
+    // windows — one with 0h unknowns, one with a benign 7h — must now produce
+    // effectively the same posterior, because the unknown days carry no
+    // evidence in either direction.
+    func testUnknownSleepDaysDoNotInflatePosteriorRisk() {
+        let now = Date()
+        let cal = Calendar.current
+        let unknownSleep: [MoodEntry] = (0..<14).map { i in
+            MoodEntry(
+                timestamp: cal.date(byAdding: .day, value: -i, to: now)!,
+                moodLevel: 0, energy: 3, sleepHours: 0, irritability: 0, anxiety: 0, note: ""
+            )
+        }
+        let benignSleep: [MoodEntry] = (0..<14).map { i in
+            MoodEntry(
+                timestamp: cal.date(byAdding: .day, value: -i, to: now)!,
+                moodLevel: 0, energy: 3, sleepHours: 7, irritability: 0, anxiety: 0, note: ""
+            )
+        }
+        let unknownResult = evaluate(vectors: FeatureStoreService.buildVectors(entries: unknownSleep))
+        let benignResult = evaluate(vectors: FeatureStoreService.buildVectors(entries: benignSleep))
+
+        XCTAssertEqual(unknownResult.posteriorRisk, benignResult.posteriorRisk, accuracy: 0.02,
+            "sleepHours==0 (unknown) must not drive posteriorRisk up vs. a benign 7h day")
+        XCTAssertEqual(rank(unknownResult.severity), rank(benignResult.severity),
+            "unknown sleep must not escalate severity")
+    }
+
     func testConfidenceBounds() {
         let scenario = RealisticMoodDatasetFactory.makeScenario(days: 60).entries
         let vectors = FeatureStoreService.buildVectors(entries: Array(scenario[20..<40]))

--- a/moodboundTests/BayesianSafetyEngineTests.swift
+++ b/moodboundTests/BayesianSafetyEngineTests.swift
@@ -68,6 +68,13 @@ final class BayesianSafetyEngineTests: XCTestCase {
         let result = evaluate(vectors: vectors)
         XCTAssertGreaterThanOrEqual(rank(result.severity), rank(.elevated),
             "N=6 with severe distress should escalate beyond .none after the double-shrinkage fix")
+        // Ceiling: routing forecast.rawValue (vs. shrunk value) into the LR
+        // raises its magnitude. Six days should not be enough to push severity
+        // all the way to .critical — that would mean the user can hit the
+        // top alert tier from less than a week of data, which is the failure
+        // mode the original shrinkage was designed to prevent.
+        XCTAssertLessThan(rank(result.severity), rank(.critical),
+            "N=6 must not be enough data to escalate to .critical, even with severe distress")
         XCTAssertGreaterThan(result.posteriorRisk, 0.22,
             "Posterior should rise meaningfully above the prior, not collapse back into it")
     }

--- a/moodboundTests/BayesianSafetyEngineTests.swift
+++ b/moodboundTests/BayesianSafetyEngineTests.swift
@@ -49,6 +49,29 @@ final class BayesianSafetyEngineTests: XCTestCase {
         XCTAssertGreaterThan(fullResult.posteriorRisk, sparseResult.posteriorRisk)
     }
 
+    // Regression for the double-shrinkage interaction: at N=6 with severe
+    // distress, the previous chain (RiskForecastService shrunk -> fed into
+    // BayesianSafetyEngine LR -> linearly shrunk again) compounded so hard
+    // that posteriorRisk landed near the prior (0.22). With (a) the LR now
+    // reading forecast.rawValue and (b) the sqrt curve, the same window
+    // should bind to at least .elevated.
+    func testIntermediateSampleStrongDistressEscalates() {
+        let now = Date()
+        let cal = Calendar.current
+        let entries: [MoodEntry] = (0..<6).map { i in
+            MoodEntry(
+                timestamp: cal.date(byAdding: .day, value: -i, to: now)!,
+                moodLevel: 3, energy: 5, sleepHours: 4, irritability: 3, anxiety: 3, note: ""
+            )
+        }
+        let vectors = FeatureStoreService.buildVectors(entries: entries)
+        let result = evaluate(vectors: vectors)
+        XCTAssertGreaterThanOrEqual(rank(result.severity), rank(.elevated),
+            "N=6 with severe distress should escalate beyond .none after the double-shrinkage fix")
+        XCTAssertGreaterThan(result.posteriorRisk, 0.22,
+            "Posterior should rise meaningfully above the prior, not collapse back into it")
+    }
+
     func testConfidenceBounds() {
         let scenario = RealisticMoodDatasetFactory.makeScenario(days: 60).entries
         let vectors = FeatureStoreService.buildVectors(entries: Array(scenario[20..<40]))

--- a/moodboundTests/BayesianSafetyEngineTests.swift
+++ b/moodboundTests/BayesianSafetyEngineTests.swift
@@ -15,6 +15,40 @@ final class BayesianSafetyEngineTests: XCTestCase {
         XCTAssertFalse(high.evidence.signals.isEmpty)
     }
 
+    // Regression: pre-shrinkage, two consecutive high-distress days could
+    // shove the likelihood ratio enough to escalate severity to .high or
+    // .critical from N=2 alone. The fix pulls posteriorRisk toward the
+    // prior (0.22) with weight Min(1, N/14), so a sparse-but-extreme series
+    // can no longer trip safety escalation by itself. The same data with
+    // N≥14 should still produce a meaningful escalation.
+    func testSparseDistressDoesNotEscalateSeverity() {
+        let now = Date()
+        let cal = Calendar.current
+        // Two days of severe distress, no preceding history.
+        let sparse: [MoodEntry] = (0..<2).map { i in
+            MoodEntry(
+                timestamp: cal.date(byAdding: .day, value: -i, to: now)!,
+                moodLevel: 3, energy: 5, sleepHours: 4, irritability: 3, anxiety: 3, note: ""
+            )
+        }
+        let sparseVectors = FeatureStoreService.buildVectors(entries: sparse)
+        let sparseResult = evaluate(vectors: sparseVectors)
+        XCTAssertLessThanOrEqual(rank(sparseResult.severity), rank(.elevated))
+
+        // Same distress pattern over a full 14-day window should reveal the
+        // true risk and escalate beyond .none.
+        let full: [MoodEntry] = (0..<14).map { i in
+            MoodEntry(
+                timestamp: cal.date(byAdding: .day, value: -i, to: now)!,
+                moodLevel: 3, energy: 5, sleepHours: 4, irritability: 3, anxiety: 3, note: ""
+            )
+        }
+        let fullVectors = FeatureStoreService.buildVectors(entries: full)
+        let fullResult = evaluate(vectors: fullVectors)
+        XCTAssertGreaterThan(rank(fullResult.severity), rank(.none))
+        XCTAssertGreaterThan(fullResult.posteriorRisk, sparseResult.posteriorRisk)
+    }
+
     func testConfidenceBounds() {
         let scenario = RealisticMoodDatasetFactory.makeScenario(days: 60).entries
         let vectors = FeatureStoreService.buildVectors(entries: Array(scenario[20..<40]))

--- a/moodboundTests/InsightEngineTests.swift
+++ b/moodboundTests/InsightEngineTests.swift
@@ -132,6 +132,42 @@ final class InsightEngineTests: XCTestCase {
         XCTAssertEqual(topNames.first ?? nil, "Alpha", "ties should resolve to the alphabetically first name")
     }
 
+    // Regression: with only 2 entries, the previous engine still emitted
+    // confident "shift" / "bumpier than usual" narrative bullets and the
+    // outlook badge could read "Rough patch", since none of those
+    // signals had a sample-size guard. The fix routes user-facing narrative
+    // through an EvidenceLevel gate; below 4 recent observations we surface
+    // a single "still learning your patterns" message instead.
+    func testSnapshotEvidenceLevelHedgesNarrativeWhenSparse() {
+        let now = Date()
+        let cal = Calendar.current
+        let entries: [MoodEntry] = (0..<2).map { i in
+            MoodEntry(
+                timestamp: cal.date(byAdding: .day, value: -i, to: now)!,
+                moodLevel: 3, energy: 5, sleepHours: 4, irritability: 3, anxiety: 3, note: ""
+            )
+        }
+        let snapshot = InsightEngine.snapshot(entries: entries, now: now)
+        XCTAssertEqual(snapshot.evidenceLevel, .insufficient)
+        XCTAssertEqual(snapshot.observationsLast14d, 2)
+        XCTAssertEqual(snapshot.safety.evidenceSignals.count, 1)
+        XCTAssertTrue(snapshot.safety.evidenceSignals.first?.lowercased().contains("learning") ?? false)
+    }
+
+    func testSnapshotEvidenceLevelEstablishedWithFullWindow() {
+        let now = Date()
+        let cal = Calendar.current
+        let entries: [MoodEntry] = (0..<14).map { i in
+            MoodEntry(
+                timestamp: cal.date(byAdding: .day, value: -i, to: now)!,
+                moodLevel: 0, energy: 3, sleepHours: 7, irritability: 0, anxiety: 0, note: ""
+            )
+        }
+        let snapshot = InsightEngine.snapshot(entries: entries, now: now)
+        XCTAssertEqual(snapshot.evidenceLevel, .established)
+        XCTAssertEqual(snapshot.observationsLast14d, 14)
+    }
+
     func testSnapshotRainyDeltaCountsOpenMeteoRainCodes() {
         let now = Date()
         let cal = Calendar.current

--- a/moodboundTests/InsightEngineTests.swift
+++ b/moodboundTests/InsightEngineTests.swift
@@ -107,6 +107,31 @@ final class InsightEngineTests: XCTestCase {
         XCTAssertEqual(snapshot.highSleepCount14d, 3)
     }
 
+    // Regression: counts.max(by:) iterated dictionary order, so two triggers
+    // tied on count returned a non-deterministic name (Anvil sometimes,
+    // Stress others). The fix sorts by (-count, name) so ties resolve
+    // alphabetically. Repeating the snapshot must always pick the same name.
+    func testSnapshotTopTriggerTieBreakIsDeterministicAndAlphabetical() {
+        let now = Date()
+        let cal = Calendar.current
+        let alpha = TriggerFactor(name: "Alpha", category: "social")
+        let zulu = TriggerFactor(name: "Zulu", category: "social")
+
+        var entries: [MoodEntry] = []
+        for i in 0..<6 {
+            let date = cal.date(byAdding: .day, value: -i, to: now)!
+            let entry = MoodEntry(timestamp: date, moodLevel: 0, energy: 3, sleepHours: 7, irritability: 0, anxiety: 0, note: "")
+            // Equal count: 3 Alpha events and 3 Zulu events across 6 days.
+            let trigger = i % 2 == 0 ? alpha : zulu
+            entry.triggerEvents = [TriggerEvent(timestamp: date, intensity: 2, trigger: trigger, moodEntry: entry)]
+            entries.append(entry)
+        }
+
+        let topNames = (0..<5).map { _ in InsightEngine.snapshot(entries: entries, now: now).topTrigger14d }
+        XCTAssertEqual(Set(topNames).count, 1, "topTrigger14d should be stable across repeated calls")
+        XCTAssertEqual(topNames.first ?? nil, "Alpha", "ties should resolve to the alphabetically first name")
+    }
+
     func testSnapshotRainyDeltaCountsOpenMeteoRainCodes() {
         let now = Date()
         let cal = Calendar.current

--- a/moodboundTests/InsightNarrativeComposerTests.swift
+++ b/moodboundTests/InsightNarrativeComposerTests.swift
@@ -15,7 +15,9 @@ final class InsightNarrativeComposerTests: XCTestCase {
                 signals: ["7-day forecast risk is elevated."]
             ),
             recommendedActions: ["Review your safety plan"],
-            messages: ["Patterns were detected."]
+            messages: ["Patterns were detected."],
+            evidenceLevel: .established,
+            observationsLast14d: 12
         )
         let topAttribution = TriggerAttribution(
             triggerName: "Stress",

--- a/moodboundTests/ModelHealthServiceTests.swift
+++ b/moodboundTests/ModelHealthServiceTests.swift
@@ -29,4 +29,30 @@ final class ModelHealthServiceTests: XCTestCase {
         XCTAssertEqual(status.level, .healthy)
         XCTAssertLessThan(status.driftScore, 0.35)
     }
+
+    // Regression: staleDays previously used `now.timeIntervalSince(latest) / 86_400`,
+    // which counts 24-hour deltas, not calendar boundaries. An entry logged
+    // yesterday at 8pm against a "now" of 6am today is 10 hours old (= 0 days
+    // by raw delta) but is clearly 1 calendar day stale — the user missed a day.
+    func testStaleDaysCountsCalendarBoundaryNotRawHours() {
+        let calendar = Calendar.current
+        let yesterdayEvening = calendar.date(from: DateComponents(year: 2026, month: 4, day: 19, hour: 20, minute: 0))!
+        let thisMorning = calendar.date(from: DateComponents(year: 2026, month: 4, day: 20, hour: 6, minute: 0))!
+
+        let vector = TemporalFeatureVector(
+            timestamp: yesterdayEvening,
+            moodLevel: 0,
+            sleepHours: 7,
+            energy: 3,
+            anxiety: 0,
+            irritability: 0,
+            medAdherenceRate7d: nil,
+            triggerLoad7d: nil,
+            volatility7d: nil,
+            circadianDrift7d: nil
+        )
+        let forecast = ProbabilisticScore(value: 0.2, ciLow: 0.1, ciHigh: 0.3, calibrationError: 0.05)
+        let status = ModelHealthService.assess(vectors: [vector], forecast: forecast, now: thisMorning)
+        XCTAssertEqual(status.staleDays, 1)
+    }
 }

--- a/moodboundTests/MoodViewModelTests.swift
+++ b/moodboundTests/MoodViewModelTests.swift
@@ -42,28 +42,37 @@ final class MoodViewModelTests: XCTestCase {
         XCTAssertEqual(filtered.count, 2)
     }
 
-    // Regression: with the previous wall-clock filter, an entry from the morning
-    // of the boundary day was silently dropped because we subtracted N*86_400s
-    // from `now` instead of anchoring to the start of `now`'s day. The
-    // entriesWithinDays(days: 7) contract is "today + 6 prior calendar days",
-    // so an entry at 23:59 of (today - 6) MUST be included and an entry at
-    // 23:59 of (today - 7) MUST NOT.
+    // Regression: the previous wall-clock filter used `now - days*86_400` as
+    // the cutoff, so the inclusion of any entry from day -N depended on the
+    // time-of-day at which the filter ran. With now=9am and days=7, an entry
+    // at 23:59 of (today-7) was wrongly *included* (it sits after the 9am
+    // cutoff seven days back), and an entry at 8am of (today-7) — i.e., the
+    // morning of the same boundary day — was wrongly *dropped* by an earlier
+    // call at 7am the next day. Anchoring to startOfDay makes the cutoff
+    // calendar-day-aligned (midnight of today - (days-1)), so both mornings
+    // and evenings of the boundary day are treated consistently.
     func testEntriesWithinDaysHonorsCalendarDayBoundary() {
         let calendar = Calendar.current
         let now = calendar.date(from: DateComponents(year: 2026, month: 4, day: 20, hour: 9, minute: 0))!
         let startToday = calendar.startOfDay(for: now)
 
+        let morningOfDayMinus6 = calendar.date(byAdding: .day, value: -6, to: startToday)!
+            .addingTimeInterval(8 * 3_600)
         let endOfDayMinus6 = calendar.date(byAdding: .day, value: -6, to: startToday)!
             .addingTimeInterval((23 * 3_600) + (59 * 60))
         let endOfDayMinus7 = calendar.date(byAdding: .day, value: -7, to: startToday)!
             .addingTimeInterval((23 * 3_600) + (59 * 60))
 
-        let inside = MoodEntry(timestamp: endOfDayMinus6, moodLevel: 0, energy: 3, sleepHours: 7, irritability: 0, anxiety: 0, note: "")
+        let morningInside = MoodEntry(timestamp: morningOfDayMinus6, moodLevel: 0, energy: 3, sleepHours: 7, irritability: 0, anxiety: 0, note: "")
+        let eveningInside = MoodEntry(timestamp: endOfDayMinus6, moodLevel: 0, energy: 3, sleepHours: 7, irritability: 0, anxiety: 0, note: "")
         let outside = MoodEntry(timestamp: endOfDayMinus7, moodLevel: 0, energy: 3, sleepHours: 7, irritability: 0, anxiety: 0, note: "")
 
-        let filtered = MoodViewModel().entriesWithinDays(entries: [inside, outside], days: 7, now: now)
-        XCTAssertEqual(filtered.count, 1)
+        let filtered = MoodViewModel().entriesWithinDays(entries: [morningInside, eveningInside, outside], days: 7, now: now)
+        XCTAssertEqual(filtered.count, 2)
+        // Both ends of the boundary day are included regardless of time-of-day.
+        XCTAssertTrue(filtered.contains { $0.timestamp == morningOfDayMinus6 })
         XCTAssertTrue(filtered.contains { $0.timestamp == endOfDayMinus6 })
+        // The previous calendar day (one day past the 7-day window) is not.
         XCTAssertFalse(filtered.contains { $0.timestamp == endOfDayMinus7 })
     }
 

--- a/moodboundTests/MoodViewModelTests.swift
+++ b/moodboundTests/MoodViewModelTests.swift
@@ -42,6 +42,31 @@ final class MoodViewModelTests: XCTestCase {
         XCTAssertEqual(filtered.count, 2)
     }
 
+    // Regression: with the previous wall-clock filter, an entry from the morning
+    // of the boundary day was silently dropped because we subtracted N*86_400s
+    // from `now` instead of anchoring to the start of `now`'s day. The
+    // entriesWithinDays(days: 7) contract is "today + 6 prior calendar days",
+    // so an entry at 23:59 of (today - 6) MUST be included and an entry at
+    // 23:59 of (today - 7) MUST NOT.
+    func testEntriesWithinDaysHonorsCalendarDayBoundary() {
+        let calendar = Calendar.current
+        let now = calendar.date(from: DateComponents(year: 2026, month: 4, day: 20, hour: 9, minute: 0))!
+        let startToday = calendar.startOfDay(for: now)
+
+        let endOfDayMinus6 = calendar.date(byAdding: .day, value: -6, to: startToday)!
+            .addingTimeInterval((23 * 3_600) + (59 * 60))
+        let endOfDayMinus7 = calendar.date(byAdding: .day, value: -7, to: startToday)!
+            .addingTimeInterval((23 * 3_600) + (59 * 60))
+
+        let inside = MoodEntry(timestamp: endOfDayMinus6, moodLevel: 0, energy: 3, sleepHours: 7, irritability: 0, anxiety: 0, note: "")
+        let outside = MoodEntry(timestamp: endOfDayMinus7, moodLevel: 0, energy: 3, sleepHours: 7, irritability: 0, anxiety: 0, note: "")
+
+        let filtered = MoodViewModel().entriesWithinDays(entries: [inside, outside], days: 7, now: now)
+        XCTAssertEqual(filtered.count, 1)
+        XCTAssertTrue(filtered.contains { $0.timestamp == endOfDayMinus6 })
+        XCTAssertFalse(filtered.contains { $0.timestamp == endOfDayMinus7 })
+    }
+
     func testValidationRejectsInvalidEnergy() {
         XCTAssertThrowsError(
             try MoodEntryValidator.validate(

--- a/moodboundTests/RiskForecastServiceTests.swift
+++ b/moodboundTests/RiskForecastServiceTests.swift
@@ -19,6 +19,28 @@ final class RiskForecastServiceTests: XCTestCase {
         XCTAssertGreaterThan(severeScore.value, stableScore.value)
     }
 
+    // Regression: with the previous integer-division formula `recent.count / 3`,
+    // a single change point saturated to 1.0 across N=1..5, then dropped
+    // discontinuously at N=6 (to 0.5). The fix uses Double division, which
+    // keeps the rate strictly decreasing as N grows past the change count.
+    func testRecentChangeRateScalesSmoothlyWithSmallN() {
+        // With 1 change point, the rate must be strictly monotone-decreasing
+        // from N=4 upward — the buggy integer-division formula returned 1.0
+        // for both N=4 and N=5.
+        let r4 = RiskForecastService.recentChangeRate(changeCount: 1, recentCount: 4)
+        let r5 = RiskForecastService.recentChangeRate(changeCount: 1, recentCount: 5)
+        let r6 = RiskForecastService.recentChangeRate(changeCount: 1, recentCount: 6)
+        let r7 = RiskForecastService.recentChangeRate(changeCount: 1, recentCount: 7)
+        XCTAssertGreaterThan(r4, r5)
+        XCTAssertGreaterThan(r5, r6)
+        XCTAssertGreaterThan(r6, r7)
+
+        // Rate is bounded in [0, 1] and saturates only when changes ≥ N/3.
+        XCTAssertEqual(RiskForecastService.recentChangeRate(changeCount: 0, recentCount: 14), 0)
+        XCTAssertEqual(RiskForecastService.recentChangeRate(changeCount: 10, recentCount: 1), 1.0)
+        XCTAssertEqual(RiskForecastService.recentChangeRate(changeCount: 1, recentCount: 3), 1.0, accuracy: 0.0001)
+    }
+
     func testUncertaintyShrinksWithMoreData() {
         let scenario = RealisticMoodDatasetFactory.makeScenario(days: 90).entries
         let shortSeries = FeatureStoreService.buildVectors(entries: Array(scenario.prefix(8)))

--- a/moodboundTests/RiskForecastServiceTests.swift
+++ b/moodboundTests/RiskForecastServiceTests.swift
@@ -23,17 +23,21 @@ final class RiskForecastServiceTests: XCTestCase {
     // a single change point saturated to 1.0 across N=1..5, then dropped
     // discontinuously at N=6 (to 0.5). The fix uses Double division, which
     // keeps the rate strictly decreasing as N grows past the change count.
+    // We pin the post-fix plateau values so a re-introduction of integer
+    // division (e.g., `Double(recentCount/3 + 1)`) that still happens to be
+    // monotone would still fail this test.
     func testRecentChangeRateScalesSmoothlyWithSmallN() {
-        // With 1 change point, the rate must be strictly monotone-decreasing
-        // from N=4 upward — the buggy integer-division formula returned 1.0
-        // for both N=4 and N=5.
         let r4 = RiskForecastService.recentChangeRate(changeCount: 1, recentCount: 4)
         let r5 = RiskForecastService.recentChangeRate(changeCount: 1, recentCount: 5)
         let r6 = RiskForecastService.recentChangeRate(changeCount: 1, recentCount: 6)
         let r7 = RiskForecastService.recentChangeRate(changeCount: 1, recentCount: 7)
-        XCTAssertGreaterThan(r4, r5)
-        XCTAssertGreaterThan(r5, r6)
-        XCTAssertGreaterThan(r6, r7)
+
+        // Direct equality pins the formula. Buggy code returned 1.0 for r4
+        // and r5 both, then 0.5 for r6 — neither monotone nor continuous.
+        XCTAssertEqual(r4, 0.75, accuracy: 0.0001)
+        XCTAssertEqual(r5, 0.6, accuracy: 0.0001)
+        XCTAssertEqual(r6, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(r7, 1.0 / (7.0 / 3.0), accuracy: 0.0001)
 
         // Rate is bounded in [0, 1] and saturates only when changes ≥ N/3.
         XCTAssertEqual(RiskForecastService.recentChangeRate(changeCount: 0, recentCount: 14), 0)


### PR DESCRIPTION
## Summary

Three loosely-related improvements bundled because they all attack the same theme: making the app behave honestly when data is missing, sparse, or ambiguous.

### Sleep handling
- **NewEntryView**: collapse the sleep section after the first entry of the day. The day's authoritative sleep is inherited so subsequent entries don't re-prompt or accidentally overwrite a real value with `0`.
- **0-hour sleep guardrail**: confirm before saving and offer to backfill from HealthKit's last-night window.
- Removed the stale `last.sleepHours` carry-forward in smart defaults that was applying yesterday's sleep to today's first entry.
- **Manual weather entry**: typing a city still hits Open-Meteo; offline manual entry takes a condition + temperature.

### Empty / cold-start UX
- **HomeView**: gate the stats grid behind 3 entries; show a baseline progress card before that.
- **InsightsView**: lift "needs data" conditions to `topCards` so empty cards collapse instead of rendering as ghosts.

### Math correctness (read-only audit + targeted fixes)

| Severity | Site | Bug |
| --- | --- | --- |
| High | `InsightEngine.topTrigger14d` | Ties broken by `Dictionary` iteration order (non-deterministic). Now: count desc, name asc. |
| High | `DirectionalSignalService` | Imputed `0.5` for missing `medAdherence` / `volatility`, pulling Pearson r toward 0. Now: pair-wise drop nils. Sleep deficit also respects `sleepHours==0` unknown convention. |
| High | `MedicationTrajectoryService` | `average([]) == 0` was being compared as a real risk score. Both arms must have observations before emitting a delta. Bounded the future-window slice. |
| High | sleep zero-as-unknown across views | `HomeView` weekly average, `InsightsView` month-over-month, `HistoryView` per-day aggregate + window summary + sleep chart all dragged averages down on unknown days. Now skip `sleepHours == 0`. |
| Medium | `RiskForecastService` | `Double(recent.count) / max(1, Double(recent.count / 3))` — integer division flattened the rate scale. Switched to Double. |
| Medium | `ModelHealthService.staleDays` | Raw timestamp delta said "0 stale" for an entry yesterday at 8pm vs now 6am. Anchor both ends to `startOfDay`. |
| Medium | `entriesWithinDays` / `HomeView` / `HistoryView` filteredEntries | Wall-clock "now - N days" dropped morning entries from the boundary day. Anchor to `startOfDay`. |
| Medium | `InsightsView` monthOverMonthCard | This-month was 31 days while last-month was 30 (biased). Now two equal `startOfDay`-anchored 30-day windows. |
| Medium | `HomeView` / `InsightsView` outlook | `outlookSummary` thresholds (70/40) didn't match `outlookBand` (75/45) — badge could say "Rough patch" while line said "bumpy". Aligned. |
| Low | streak label, recovery half-life label | "1 days" / "0 day" pluralization. |

## Test plan
- [x] `xcodebuild build` (iPhone 17, latest iOS)
- [x] `xcodebuild test -only-testing:moodboundTests` — **116 / 116 passing**
- [ ] Manual smoke: log a fresh entry on a clean device → confirm baseline card on HomeView
- [ ] Manual smoke: log an entry with sleep skipped → confirm 0-hour guardrail
- [ ] Manual smoke: log a city-only weather entry → confirm Open-Meteo lookup
- [ ] Manual smoke: open InsightsView with <14 days of data → confirm empty cards don't render