### PR TITLE
Sleep-unknown leak in insight snapshot + vague 'activity' copy

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -11,8 +11,8 @@ let project = Project(
             bundleId: "dev.tuist.Moodbound",
             deploymentTargets: .iOS("17.0"),
             infoPlist: .extendingDefault(with: [
-                "CFBundleShortVersionString": .string("1.2.0"),
-                "CFBundleVersion": .string("15"),
+                "CFBundleShortVersionString": .string("1.2.1"),
+                "CFBundleVersion": .string("17"),
                 "CFBundleIconName": .string("AppIcon"),
                 "UILaunchScreen": .dictionary([:]),
                 "UISupportedInterfaceOrientations": .array([

--- a/moodbound/Services/AdaptiveCheckinService.swift
+++ b/moodbound/Services/AdaptiveCheckinService.swift
@@ -69,7 +69,11 @@ enum AdaptiveCheckinService {
     }
 
     private static func sleepStdDev(entries: [MoodEntry]) -> Double {
-        let values = entries.suffix(14).map(\.sleepHours)
+        // sleepHours == 0 is the "unknown" sentinel. Including zeros mixes
+        // real 7-8h nights with phantom zeros and produces a huge stddev,
+        // which would flag sleep timing variability as the top uncertainty
+        // driver purely because of unlogged days.
+        let values = entries.suffix(14).map(\.sleepHours).filter { $0 > 0 }
         guard values.count > 1 else { return 0 }
         let mean = values.reduce(0, +) / Double(values.count)
         let variance = values.reduce(0) { sum, value in

--- a/moodbound/Services/InsightEngine.swift
+++ b/moodbound/Services/InsightEngine.swift
@@ -62,7 +62,11 @@ enum InsightEngine {
         let viewModel = MoodViewModel()
         let recent14 = viewModel.entriesWithinDays(entries: entries, days: 14, now: now)
 
-        let lowSleepCount = recent14.filter { $0.sleepHours < 6 }.count
+        // sleepHours == 0 is the app's "unknown" sentinel (HealthKit miss or user
+        // skipped). Exclude unknowns so a run of unlogged days doesn't inflate the
+        // low-sleep count and mislead every downstream surface (Home nudge,
+        // Insights card, pattern story, conformal confidence).
+        let lowSleepCount = recent14.filter { $0.sleepHours > 0 && $0.sleepHours < 6 }.count
         let highSleepCount = recent14.filter { $0.sleepHours > 10 }.count
         let features = FeatureStoreService.buildVectors(entries: entries)
         let latent = LatentStateService.inferStates(vectors: features)

--- a/moodbound/Views/InsightsView.swift
+++ b/moodbound/Views/InsightsView.swift
@@ -736,7 +736,7 @@ struct InsightsView: View {
         case "sleep-regularity":
             return "Consistent sleep is one of the strongest stabilizers for mood."
         case "activation-slope":
-            return "Whether your energy and activity have been rising, falling, or flat recently."
+            return "Whether your energy has been rising, falling, or flat recently."
         case "recovery-half-life":
             return "How quickly you tend to bounce back after a rough patch."
         default:
@@ -1100,7 +1100,7 @@ struct InsightsView: View {
             if sleepIrregularity >= 4 {
                 return (
                     "Mixed",
-                    "Your mood seems okay on average, but your sleep and activity are all over the place.",
+                    "Your mood seems okay on average, but your sleep hasn't been very consistent.",
                     .purple
                 )
             }

--- a/moodboundTests/AdaptiveCheckinServiceTests.swift
+++ b/moodboundTests/AdaptiveCheckinServiceTests.swift
@@ -49,4 +49,38 @@ final class AdaptiveCheckinServiceTests: XCTestCase {
         )
         XCTAssertLessThanOrEqual(prompts.count, 2)
     }
+
+    // Regression: sleepStdDev previously included sleepHours == 0 (the
+    // "unknown" sentinel), so a user with real consistent sleep but a few
+    // HealthKit misses looked hugely irregular and sleep-routine got surfaced
+    // as a top-information prompt. With zeros excluded, a user whose only
+    // sleep signal is a handful of logged 7-8h nights should not trigger the
+    // sleep-routine prompt as a top-gain candidate.
+    func testUnknownSleepDoesNotInflateSleepPromptGain() {
+        let now = Date()
+        let cal = Calendar.current
+        // 14 days where most are unknown (0h) and a few are steady 7.5h —
+        // the actual recorded sleep is consistent; only unknowns vary.
+        let entries: [MoodEntry] = (0..<14).map { i in
+            let sleep: Double = (i % 4 == 0) ? 7.5 : 0
+            return MoodEntry(
+                timestamp: cal.date(byAdding: .day, value: -i, to: now)!,
+                moodLevel: 0, energy: 3, sleepHours: sleep,
+                irritability: 0, anxiety: 0, note: ""
+            )
+        }
+        let vectors = FeatureStoreService.buildVectors(entries: entries)
+        let forecast = ProbabilisticScore(value: 0.3, ciLow: 0.15, ciHigh: 0.5, calibrationError: 0.05)
+
+        let prompts = AdaptiveCheckinService.nextPrompts(
+            entries: entries,
+            vectors: vectors,
+            forecast: forecast,
+            attributions: [],
+            maxPrompts: 3
+        )
+        let sleepPrompt = prompts.first(where: { $0.id == "sleep-routine" })
+        XCTAssertNil(sleepPrompt,
+            "sleep-routine must not surface when actual recorded sleep is consistent — unknowns should not inflate its information gain")
+    }
 }

--- a/moodboundTests/InsightEngineTests.swift
+++ b/moodboundTests/InsightEngineTests.swift
@@ -107,6 +107,28 @@ final class InsightEngineTests: XCTestCase {
         XCTAssertEqual(snapshot.highSleepCount14d, 3)
     }
 
+    // Regression: sleepHours == 0 is the app's "unknown" sentinel. Previously
+    // the low-sleep count used `$0.sleepHours < 6`, so a run of HealthKit
+    // misses (or days the user skipped) was counted as 14 days of severe
+    // sleep deprivation. That drove the Home nudge, the Insights "Under-
+    // sleeping" card, the pattern-story irregularity copy, and the conformal
+    // confidence derating — all from phantom data. The fix excludes zeros.
+    func testSnapshotSleepCountsExcludeUnknowns() {
+        let now = Date()
+        let cal = Calendar.current
+        let entries: [MoodEntry] = (0..<14).map { i in
+            MoodEntry(
+                timestamp: cal.date(byAdding: .day, value: -i, to: now)!,
+                moodLevel: 0, energy: 3, sleepHours: 0,
+                irritability: 0, anxiety: 0, note: ""
+            )
+        }
+        let snapshot = InsightEngine.snapshot(entries: entries, now: now)
+        XCTAssertEqual(snapshot.lowSleepCount14d, 0,
+            "unknown sleep (0h) must not count as low sleep")
+        XCTAssertEqual(snapshot.highSleepCount14d, 0)
+    }
+
     // Regression: counts.max(by:) iterated dictionary order, so two triggers
     // tied on count returned a non-deterministic name (Anvil sometimes,
     // Stress others). The fix sorts by (-count, name) so ties resolve


### PR DESCRIPTION
## Summary
Follow-up to #7. Two more surfaces were still treating `sleepHours == 0` (the app's unknown sentinel) as real data, plus a copy bug where the UI mentioned an "activity" signal that doesn't exist.

- [InsightEngine.swift:65](moodbound/Services/InsightEngine.swift:65) — `lowSleepCount14d` / `highSleepCount14d` counted unlogged days as severe sleep deprivation. These counts drive the Home sleep nudge, the Insights "Under-sleeping" card, the pattern-story `sleepIrregularity >= 4` gate, and the conformal confidence derating. One run of HealthKit misses = four phantom surfaces lighting up.
- [AdaptiveCheckinService.swift:71](moodbound/Services/AdaptiveCheckinService.swift:71) — `sleepStdDev` included 0h unknowns in its variance. Mixing phantom zeros with real 7-8h nights produced a huge stddev, pushing the sleep-routine prompt to the top of information gain purely because some days weren't logged.
- [InsightsView.swift:1103](moodbound/Views/InsightsView.swift:1103) + [InsightsView.swift:739](moodbound/Views/InsightsView.swift:739) — the "Mixed" phase copy and the activation-slope card explanation both said "activity," but nothing in the app measures activity (no step count, no movement data). The "Mixed" gate is sleep-only; activation-slope is energy + mood. Copy now matches the actual data.

## Test plan
- [x] New regression `testSnapshotSleepCountsExcludeUnknowns` in `InsightEngineTests` — 14 days of 0h sleep must not produce low-sleep count.
- [x] New regression `testUnknownSleepDoesNotInflateSleepPromptGain` in `AdaptiveCheckinServiceTests` — 14 days mostly unknown with a few consistent 7.5h nights must not surface the sleep-routine prompt.
- [x] Existing `testSnapshotSleepCounts` still passes (real low/high sleep still counts).
- [x] `BayesianSafetyEngineTests` (including `testUnknownSleepDaysDoNotInflatePosteriorRisk` from #7) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)